### PR TITLE
Fixing runtime annotations

### DIFF
--- a/classpath/avian/VMMethod.java
+++ b/classpath/avian/VMMethod.java
@@ -24,4 +24,8 @@ public class VMMethod {
   public MethodAddendum addendum;
   public VMClass class_;
   public Object code;
+  
+  public boolean hasAnnotations() {
+    return addendum != null && addendum.annotationTable != null;
+  }
 }

--- a/classpath/java/lang/reflect/Method.java
+++ b/classpath/java/lang/reflect/Method.java
@@ -170,7 +170,7 @@ public class Method<T> extends AccessibleObject implements Member {
   }
 
   public <T extends Annotation> T getAnnotation(Class<T> class_) {
-    if (vmMethod.addendum.annotationTable != null) {
+    if (vmMethod.hasAnnotations()) {
       Object[] table = (Object[]) vmMethod.addendum.annotationTable;
       for (int i = 0; i < table.length; ++i) {
         Object[] a = (Object[]) table[i];
@@ -183,7 +183,7 @@ public class Method<T> extends AccessibleObject implements Member {
   }
 
   public Annotation[] getAnnotations() {
-    if (vmMethod.addendum.annotationTable != null) {
+    if (vmMethod.hasAnnotations()) {
       Object[] table = (Object[]) vmMethod.addendum.annotationTable;
       Annotation[] array = new Annotation[table.length];
       for (int i = 0; i < table.length; ++i) {

--- a/classpath/java/lang/reflect/Proxy.java
+++ b/classpath/java/lang/reflect/Proxy.java
@@ -358,7 +358,7 @@ public class Proxy {
     int[] interfaceIndexes = new int[interfaces.length];
     for (int i = 0; i < interfaces.length; ++i) {
       interfaceIndexes[i] = ConstantPool.addClass
-        (pool, interfaces[i].getName());
+        (pool, interfaces[i].getName().replace('.', '/'));
     }
 
     Map<String,avian.VMMethod> virtualMap = new HashMap();

--- a/makefile
+++ b/makefile
@@ -685,7 +685,10 @@ vm-classes = \
 	avian/*.class \
 	avian/resource/*.class
 
+test-support-sources = $(shell find $(test)/avian/ -name '*.java')
 test-sources = $(wildcard $(test)/*.java)
+test-sources += $(test-support-sources)
+test-support-classes = $(call java-classes, $(test-support-sources),$(test),$(test-build))
 test-classes = $(call java-classes,$(test-sources),$(test),$(test-build))
 test-dep = $(test-build).dep
 
@@ -765,7 +768,7 @@ vg: build
 test: build
 	$(library-path) /bin/sh $(test)/test.sh 2>/dev/null \
 		$(test-executable) $(mode) "$(test-flags)" \
-		$(call class-names,$(test-build),$(test-classes)) \
+		$(call class-names,$(test-build),$(filter-out $(test-support-classes), $(test-classes))) \
 		$(continuation-tests) $(tail-tests)
 
 .PHONY: tarball

--- a/test/Annotations.java
+++ b/test/Annotations.java
@@ -1,6 +1,9 @@
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
+
+import avian.testing.annotations.Color;
+import avian.testing.annotations.Test;
+import avian.testing.annotations.TestEnum;
+import avian.testing.annotations.TestInteger;
 
 public class Annotations {
   private static void expect(boolean v) {
@@ -18,6 +21,12 @@ public class Annotations {
            .equals(Color.Red));
 
     expect(((TestInteger) m.getAnnotation(TestInteger.class)).value() == 42);
+    
+    expect(m.getAnnotations().length == 3);
+    
+    Method noAnno = Annotations.class.getMethod("noAnnotation");
+    expect(noAnno.getAnnotation(Test.class) == null);
+    expect(noAnno.getAnnotations().length == 0);
   }
 
   @Test("couscous")
@@ -26,24 +35,8 @@ public class Annotations {
   public static void foo() {
     
   }
-
-  @Retention(RetentionPolicy.RUNTIME)
-  private @interface Test {
-    public String value();
+  
+  public static void noAnnotation() {
+    
   }
-
-  @Retention(RetentionPolicy.RUNTIME)
-  private @interface TestEnum {
-    public Color value();
-  }
-
-  @Retention(RetentionPolicy.RUNTIME)
-  private @interface TestInteger {
-    public int value();
-  }
-
-  private static enum Color {
-    Red, Yellow, Blue
-  }
-
 }

--- a/test/avian/testing/annotations/Color.java
+++ b/test/avian/testing/annotations/Color.java
@@ -1,0 +1,5 @@
+package avian.testing.annotations;
+
+public enum Color {
+  Red, Yellow, Blue
+}

--- a/test/avian/testing/annotations/Test.java
+++ b/test/avian/testing/annotations/Test.java
@@ -1,0 +1,9 @@
+package avian.testing.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Test {
+  public String value();
+}

--- a/test/avian/testing/annotations/TestEnum.java
+++ b/test/avian/testing/annotations/TestEnum.java
@@ -1,0 +1,8 @@
+package avian.testing.annotations;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestEnum {
+  public Color value();
+}

--- a/test/avian/testing/annotations/TestInteger.java
+++ b/test/avian/testing/annotations/TestInteger.java
@@ -1,0 +1,8 @@
+package avian.testing.annotations;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestInteger {
+  public int value();
+}


### PR DESCRIPTION
We were not properly converting dots to slashes internally for package names
and we did not properly handle Method.getAnnotations() and
Method.getAnnotation(Class<T>) on methods without any annotations.

Added some tests to cover these cases.
