### PR TITLE
Add a non-versioned SONAME to Avian libjvm.so

### DIFF
--- a/makefile
+++ b/makefile
@@ -223,6 +223,7 @@ build-lflags = -lz -lpthread -ldl
 
 lflags = $(common-lflags) -lpthread -ldl
 
+soname-flag = -Wl,-soname -Wl,$(so-prefix)jvm$(so-suffix)
 version-script-flag = -Wl,--version-script=openjdk.ld
 
 build-system = posix
@@ -1160,7 +1161,8 @@ ifdef msvc
 		-IMPLIB:$(build)/$(name).lib -MANIFESTFILE:$(@).manifest
 	$(mt) -manifest $(@).manifest -outputresource:"$(@);2"
 else
-	$(ld) $(^) $(version-script-flag)	$(shared) $(lflags) $(bootimage-lflags) \
+	$(ld) $(^) $(version-script-flag) $(soname-flag) \
+		$(shared) $(lflags) $(bootimage-lflags) \
 		-o $(@)
 endif
 	$(strip) $(strip-all) $(@)


### PR DESCRIPTION
that matches the Hotspot Server/Client libjvm.so SONAME,
this allow libjava.so in OpenJDK 7 to find the Avian libjvm.so during ldopen.

This patch simply add a SONAME section to the library:
objdump -x build/linux-i386-openjdk/libjvm.so | grep SONAME
  SONAME               libjvm.so
# build avian and prepare the test:

sudo mkdir /usr/lib/jvm/java-7-openjdk-i386/jre/lib/i386/avian
sudo cp build/linux-i386-openjdk/libjvm.so /usr/lib/jvm/java-7-openjdk-i386/jre/lib/i386/avian
# Add -avian KNOWN to the end of the jvm.cfg file in order to make java -avian work

sudo sh -c "echo '-avian KNOWN' >> /usr/lib/jvm/java-7-openjdk-i386/jre/lib/i386/jvm.cfg"
# Output before adding SONAME:

/usr/lib/jvm/java-7-openjdk-i386/bin/java -avian -version
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
# Output after adding SONAME:

/usr/lib/jvm/java-7-openjdk-i386/bin/java -avian -version
java version "1.7.0_03"
OpenJDK Runtime Environment (IcedTea7 2.1.1pre) (7~u3-2.1.1~pre1-1ubuntu3)
Avian (build null, null)
