### PR TITLE
Set java.vm.info based on makefile info= and

### DIFF
--- a/makefile
+++ b/makefile
@@ -194,6 +194,7 @@ target-cflags = -DTARGET_BYTES_PER_WORD=$(pointer-size)
 common-cflags = $(warnings) -fno-rtti -fno-exceptions -I$(classpath-src) \
 	"-I$(JAVA_HOME)/include" -idirafter $(src) -I$(build) $(classpath-cflags) \
 	-D__STDC_LIMIT_MACROS -D_JNI_IMPLEMENTATION_ -DAVIAN_VERSION=\"$(version)\" \
+	-DAVIAN_INFO="\"$(info)\"" \
 	-DUSE_ATOMIC_OPERATIONS -DAVIAN_JAVA_HOME=\"$(javahome)\" \
 	-DAVIAN_EMBED_PREFIX=\"$(embed-prefix)\" $(target-cflags)
 

--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -3006,6 +3006,12 @@ jvmInitProperties(Thread* t, uintptr_t* arguments)
                      "Avian Contributors");
 
   local::setProperty(t, method, *properties, "java.vm.name","Avian");
+#ifdef AVIAN_VERSION
+  local::setProperty(t, method, *properties, "java.vm.version",AVIAN_VERSION);
+#endif
+#ifdef AVIAN_INFO
+  local::setProperty(t, method, *properties, "java.vm.info",AVIAN_INFO);
+#endif
 
   local::setProperty
     (t, method, *properties, "java.home",


### PR DESCRIPTION
set java.vm.version based on makefile version=
in order to display relevant OpenJDK -version information.

Signed-off-by: Matthias Klose doko@ubuntu.com
Signed-off-by: Xerxes Rånby xerxes@zafena.se
