### PR TITLE
Fix missing armv4 blx and bkpt compile errors.

### DIFF
--- a/src/arm.S
+++ b/src/arm.S
@@ -62,7 +62,12 @@ LOCAL(loop):
   vldmia  r7, {d0-d7}
 #endif
 
+#if defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__)
+  mov   lr, pc
+  bx    r4
+#else
   blx   r4         // call function
+#endif
   add   sp, sp, r5 // deallocate stack
 
 #if defined(__VFP_FP__) && (! defined(__SOFTFP__)) && (! defined(__QNX__))
@@ -108,7 +113,12 @@ GLOBAL(vmRun):
   mov   r12, r0
   ldr   r0, [r2, #CHECKPOINT_THREAD]
 
+#if defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__)
+  mov   lr, pc
+  bx    r12
+#else
   blx   r12
+#endif
 
 .globl GLOBAL(vmRun_returnAddress)
 .align 2

--- a/src/compile-arm.S
+++ b/src/compile-arm.S
@@ -75,7 +75,12 @@ LOCAL(vmInvoke_argumentTest):
   mov   r8, r0
 
   // load and call function address
+#if defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__)
+  mov   lr, pc
+  bx    r1
+#else
   blx   r1
+#endif
 
 .globl GLOBAL(vmInvoke_returnAddress)
 .align 2
@@ -228,5 +233,9 @@ LOCAL(vmJumpAndInvoke_getAddress_word):
 #else // not AVIAN_CONTINUATIONS
    // vmJumpAndInvoke should only be called when continuations are
    // enabled
+#if defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__)
+   // TODO: armv4 do not have bkpt
+#else
    bkpt
+#endif
 #endif // not AVIAN_CONTINUATIONS


### PR DESCRIPTION
Replace blx by a mov, bx, pair.
Remove use of the bkpt instruction. TODO: find a replacement for bkpt on armv4.
Passes the same unit tests compared to the armv5+ builds.
This change will enable Debian armel to build and package Avian.

Signed-off-by: Xerxes Rånby xerxes@zafena.se
