### PR TITLE
gcc define __ARM_PCS_VFP for -mfloat-abi=hard, use it to detect armhf

### DIFF
--- a/src/arm.S
+++ b/src/arm.S
@@ -57,7 +57,7 @@ LOCAL(loop):
   // setup argument registers if necessary
   tst     r6, r6
   ldmneia r6, {r0-r3}
-#if defined(__VFP_FP__) && (! defined(__SOFTFP__)) && (! defined(__QNX__))
+#if defined(__ARM_PCS_VFP)
   // and VFP registers
   vldmia  r7, {d0-d7}
 #endif
@@ -70,7 +70,7 @@ LOCAL(loop):
 #endif
   add   sp, sp, r5 // deallocate stack
 
-#if defined(__VFP_FP__) && (! defined(__SOFTFP__)) && (! defined(__QNX__))
+#if defined(__ARM_PCS_VFP)
   cmp   r8,#FLOAT_TYPE
   bne   LOCAL(double)
   fmrs  r0,s0

--- a/src/arm.cpp
+++ b/src/arm.cpp
@@ -245,7 +245,17 @@ inline int bpl(int offset) { return SETCOND(b(offset), PL); }
 inline int fmstat() { return fmrx(15, FPSCR); }
 // HARDWARE FLAGS
 bool vfpSupported() {
-  return true; // TODO
+  // TODO: Use at runtime detection
+#if defined(__ARM_PCS_VFP)  
+  // armhf
+  return true;
+#else
+  // armel
+  // TODO: allow VFP use for -mfloat-abi=softfp armel builds.
+  // GCC -mfloat-abi=softfp flag allows use of VFP while remaining compatible
+  // with soft-float code. 
+  return false;
+#endif
 }
 }
 

--- a/src/arm.h
+++ b/src/arm.h
@@ -163,7 +163,7 @@ dynamicCall(void* function, uintptr_t* arguments, uint8_t* argumentTypes,
   for (unsigned ati = 0; ati < argumentCount; ++ ati) {
     switch (argumentTypes[ati]) {
     case DOUBLE_TYPE:
-#if (defined(__VFP_FP__) && !defined(__SOFTFP__)) && !defined(__QNX__)
+#if defined(__ARM_PCS_VFP)
       {
         if (vfpIndex + Alignment <= VfpCount) {
           if (vfpIndex % Alignment) {


### PR DESCRIPTION
This enable Debian armel
make test
builds to pass all tests using a openrd-client armv5 machine.

Signed-off-by: Xerxes Rånby xerxes@zafena.se
