### PR TITLE
A simple fix to accept upper case size suffixes for the -Xm parameters

### DIFF
--- a/src/jnienv.cpp
+++ b/src/jnienv.cpp
@@ -3345,11 +3345,11 @@ parseSize(const char* s)
   RUNTIME_ARRAY(char, buffer, length + 1);
   if (length == 0) {
     return 0;
-  } else if (s[length - 1] == 'k') {
+  } else if (s[length - 1] == 'k' or s[length - 1] == 'K') {
     memcpy(RUNTIME_ARRAY_BODY(buffer), s, length - 1);
     RUNTIME_ARRAY_BODY(buffer)[length - 1] = 0;
     return atoi(RUNTIME_ARRAY_BODY(buffer)) * 1024;
-  } else if (s[length - 1] == 'm') {
+  } else if (s[length - 1] == 'm' or s[length - 1] == 'M') {
     memcpy(RUNTIME_ARRAY_BODY(buffer), s, length - 1);
     RUNTIME_ARRAY_BODY(buffer)[length - 1] = 0;
     return atoi(RUNTIME_ARRAY_BODY(buffer)) * 1024 * 1024;


### PR DESCRIPTION
The java command accepts upper case K and M suffixes. However, if you pass these to avian, the suffix is ignored, giving you very small heap sizes and unhelpful core dumps happen.

This patch allows upper case K and M suffixes.
