### PR TITLE
Added some members that should not be removed or renamed

### DIFF
--- a/openjdk.pro
+++ b/openjdk.pro
@@ -246,3 +246,39 @@
  }
 
 -keep class sun.net.www.protocol.jar.Handler
+
+# These concurrent classes refer to certain members reflectively in their static initializers
+-keepclassmembers class java.util.concurrent.ConcurrentHashMap$HashEntry {
+	*** next;
+}
+
+-keepclassmembers class java.util.concurrent.CopyOnWriteArrayList {
+	*** lock;
+}
+
+-keepclassmembers class java.util.concurrent.CountDownLatch {
+	*** allocationSpinLock;
+}
+
+-keepclassmembers class java.util.concurrent.PriorityBlockingQueue {
+	*** allocationSpinLock;
+}
+
+-keepclassmembers class java.util.concurrent.SynchronousQueue$TransferStack {
+	*** head;
+}
+
+-keepclassmembers class java.util.concurrent.ConcurrentLinkedQueue {
+	*** head;
+	*** tail;
+}
+
+-keepclassmembers class java.util.concurrent.ConcurrentLinkedQueue$Node {
+	*** item;
+	*** next;
+}
+
+-keepclassmembers class java.util.concurrent.SynchronousQueue$TransferStack$SNode {
+	*** match;
+	*** next;
+}


### PR DESCRIPTION
I have found and added a couple of fields that should not be removed or renamed from the OpenJDK class library, as the classes refer to these reflectively in their static initializers.
