### PR TITLE
Change Thread's isInterrupted() to non-static method

### DIFF
--- a/classpath/java/lang/Thread.java
+++ b/classpath/java/lang/Thread.java
@@ -151,8 +151,8 @@ public class Thread implements Runnable {
 
   private static native boolean interrupted(long peer);
 
-  public static boolean isInterrupted() {
-    return currentThread().interrupted;
+  public boolean isInterrupted() {
+    return interrupted;
   }
 
   public static void sleep(long milliseconds) throws InterruptedException {


### PR DESCRIPTION
Change isInterrupted() to be an instance method to match the same method in Java's standard classpath.
