### PR TITLE
Windows XP

### DIFF
--- a/openjdk-src.mk
+++ b/openjdk-src.mk
@@ -196,6 +196,8 @@ ifeq ($(platform),windows)
 		$(openjdk-src)/windows/native/java/net/NetworkInterface_winXP.c \
 		$(openjdk-src)/windows/native/java/net/SocketInputStream.c \
 		$(openjdk-src)/windows/native/java/net/SocketOutputStream.c \
+		$(openjdk-src)/windows/native/java/net/TwoStacksPlainDatagramSocketImpl.c \
+		$(openjdk-src)/windows/native/java/net/TwoStacksPlainSocketImpl.c \
 		$(openjdk-src)/windows/native/java/util/WindowsPreferences.c \
 		$(openjdk-src)/windows/native/java/util/logging.c \
 		$(openjdk-src)/windows/native/java/util/TimeZone_md.c \
@@ -216,6 +218,9 @@ ifeq ($(platform),windows)
 
 	openjdk-headers-classes += \
 		java.net.DualStackPlainSocketImpl \
+		java.net.SocketImpl \
+		java.net.TwoStacksPlainDatagramSocketImpl \
+		java.net.TwoStacksPlainSocketImpl \
 		java.lang.ProcessImpl \
 		sun.io.Win32ErrorMode \
 		sun.nio.ch.WindowsSelectorImpl \

--- a/openjdk.pro
+++ b/openjdk.pro
@@ -141,6 +141,24 @@
    <fields>;
  }
 
+-keepclassmembers class java.net.TwoStacksPlainSocketImpl {
+  *** fd1;
+  *** lastfd;
+}
+
+-keepclassmembers class java.net.AbstractPlainSocketImpl {
+  *** timeout;
+  *** trafficClass;
+}
+
+-keepclassmembers class java.net.SocketImpl {
+  *** serverSocket;
+  *** fd;
+  *** address;
+  *** port;
+  *** localport;
+}
+
 -keepclassmembers class java.io.FileInputStream {
    private java.io.FileDescriptor fd;   
  }


### PR DESCRIPTION
This patch includes some files that were missing but needed on Windows XP (and if the property java.net.preferIPv4Stack is true)
