### PR TITLE
Fix compilation errors after changes to #define THREAD_RUNTIME_ARRAY

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -1873,7 +1873,7 @@ loadLibrary(Thread* t, object, uintptr_t* arguments)
 
 #ifdef AVIAN_OPENJDK_SRC
   if (not absolute) {
-    if (strcmp(n, "net") == 0) {
+    if (strcmp(n_body, "net") == 0) {
       bool ran;
 
       { ACQUIRE(t, t->m->classLock);
@@ -1890,7 +1890,7 @@ loadLibrary(Thread* t, object, uintptr_t* arguments)
       }
 
       return;
-    } else if (strcmp(n, "management") == 0) { 
+    } else if (strcmp(n_body, "management") == 0) { 
       bool ran;
 
       { ACQUIRE(t, t->m->classLock);
@@ -1907,8 +1907,8 @@ loadLibrary(Thread* t, object, uintptr_t* arguments)
       }
 
       return;     
-    } else if (strcmp(n, "zip") == 0
-               or strcmp(n, "nio") == 0)
+    } else if (strcmp(n_body, "zip") == 0
+               or strcmp(n_body, "nio") == 0)
     {
       return;
     }


### PR DESCRIPTION
Recent changes to the #define THREAD_RUNTIME_ARRAY broke the classpath-openjdk.cpp build
