### PR TITLE
Keep java.net.SocketTimeoutException for OpenJDK

### DIFF
--- a/openjdk.pro
+++ b/openjdk.pro
@@ -136,6 +136,7 @@
    public InetSocketAddress(java.net.InetAddress, int);   
  }
 -keep class java.net.ServerSocket
+-keep class java.net.SocketTimeoutException
 
 -keepclassmembers class java.net.PlainSocketImpl {
    <fields>;


### PR DESCRIPTION
java.net.SocketTimeoutException is used from native code in java.net.SocketInputStream.socketRead0
