### PR TITLE
Fix obscure File.mkdirs() and File.exists() permissions failure

### DIFF
--- a/classpath/java-io.cpp
+++ b/classpath/java-io.cpp
@@ -126,8 +126,12 @@ OPEN(string_t path, int mask, int mode)
 inline bool
 exists(string_t path)
 {
+#ifdef PLATFORM_WINDOWS
+  return GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES;
+#else
   STRUCT_STAT s;
   return STAT(path, &s) == 0;
+#endif
 }
 
 inline int


### PR DESCRIPTION
On windows, there are obscure cases where _wstat can return non-zero for a path that
actually exists, but the native GetFileAttributes returns valid attributes.  This is
the case in particular when the user or process doesn't have permissions to access
the directory (for instance, anything outside of %temp%\Low, when running as a
low-integrity process).

This was causing problems with .mkdirs() - which first tries to check if the parent
exists, and creates it if it doesn't. In our particular case, the exists() was
returning false for the parent, even though it exists, and .mkdir() works fine,
mkdirs() fails for the same directory.
