### PR TITLE
Handle case in addThread when both arguments are the same

### DIFF
--- a/src/avian/machine.h
+++ b/src/avian/machine.h
@@ -1995,7 +1995,7 @@ addThread(Thread* t, Thread* p)
   ACQUIRE_RAW(t, t->m->stateLock);
 
   assert(t, p->state == Thread::NoState);
-  expect(t, t->state == Thread::ActiveState || t->state == Thread::ExclusiveState);
+  expect(t, t->state == Thread::ActiveState || t->state == Thread::ExclusiveState || t->state == Thread::NoState);
 
   p->state = Thread::IdleState;
   ++ t->m->threadCount;


### PR DESCRIPTION
attachThread calls addThread with both arguments being the same pointer, but the current assert and expect checks expect mutually exclusive states for the two arguments. This pull request adds Thread::NoState to the allowable states for the t argument to match what we require from p's state.
