### PR TITLE
Fix 16-byte boundary in Linux x86

### DIFF
--- a/src/x86.S
+++ b/src/x86.S
@@ -450,10 +450,10 @@ GLOBAL(vmNativeCall):
    
    subl   %ecx,%esp
 
-#  ifdef __APPLE__
-   // align to a 16 byte boundary on Darwin
+//#  ifdef __APPLE__
+   // align to a 16 byte boundary
    andl   $0xFFFFFFF0,%esp
-#  endif
+//#  endif
    
    // copy arguments into place
    movl   $0,%ecx


### PR DESCRIPTION
GCC now assumes by default that the stack is aligned to a 16-byte boundary in Linux x86, so let's do our part to honour that. :)
Otherwise native code that depends on the stack to be aligned to 16 bytes would seg fault (like SSE).
https://groups.google.com/forum/#!topic/avian/SyCl-Jfw2U8
