### PR TITLE
add proper argument escaping in Runtime.exec for windows

### DIFF
--- a/classpath/java-lang.cpp
+++ b/classpath/java-lang.cpp
@@ -229,7 +229,7 @@ void appendN(char** dest, char ch, size_t length) {
   }
 }
 
-bool needsEscape(const char* src; size_t length) {
+bool needsEscape(const char* src, size_t length) {
   const char* end = src + length;
   for(const char* ptr = src; ptr < end; ptr++) {
     switch(*ptr) {


### PR DESCRIPTION
Windows is weird.  We'll just start there.

Windows only recognizes a SINGLE string argument ("command line").  This means that it forces every application to parse this string into it's multiple unix-style arguments.  Most applications will use the standard CommandLineToArgv API (which has a consistent algorithm for parsing arguments), but this is by no means a requirement.  An application could choose to parse arguments its own way, or even not parse them out at all - using the single string as one big argument.

This makes the situation painful for applications that assume windows programs actually take multiple arguments (as is the common case).  The exec'ing application must decide how to escape it's arguments for the target application's benefit.  One format won't (necessarily) work for all programs.

The current bug in avian is that it makes no affordance for spaces in arguments.  It joins arguments with spaces, and (presumably) leaves it up to the Java application to handle the escaping itself.  OpenJDK, on the other hand, makes a simple effort to surround arguments in quotes and escape back-slashes where appropriate - but passes through arguments already surrounded in quotes.

The algorithm implemented in this commit is taken from:
http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx

... which seems like a pretty definitive source on the matter.
