### PR TITLE
Bugfixes for Mac OS X, etc.

### DIFF
--- a/src/avian/x86.h
+++ b/src/avian/x86.h
@@ -30,8 +30,8 @@
 
 #ifdef __APPLE__
 #  include "mach/mach_types.h"
-#  include "mach/i386/thread_act.h"
-#  include "mach/i386/thread_status.h"
+#  include "mach/thread_act.h"
+#  include "mach/thread_status.h"
 
 #  if __DARWIN_UNIX03 && defined(_STRUCT_X86_EXCEPTION_STATE32)
 #    define FIELD(x) __##x

--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -284,7 +284,9 @@ struct JmmInterface {
 
 const unsigned InterfaceVersion = 4;
 const unsigned PageSize = 4 * 1024;
+#ifdef AVIAN_OPENJDK_SRC
 const int VirtualFileBase = 1000000000;
+#endif
 
 Machine* globalMachine;
 

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -50,7 +50,9 @@ const bool DebugNatives = false;
 const bool DebugCallTable = false;
 const bool DebugMethodTree = false;
 const bool DebugFrameMaps = false;
+#ifndef NDEBUG
 const bool DebugIntrinsics = false;
+#endif
 
 const bool CheckArrayBounds = true;
 

--- a/src/tools/type-generator/main.cpp
+++ b/src/tools/type-generator/main.cpp
@@ -27,7 +27,7 @@
 
 #define UNUSED __attribute__((unused))
 
-inline void operator delete(void*) { abort(); }
+void operator delete(void*) { abort(); }
 
 extern "C" void __cxa_pure_virtual(void) { abort(); }
 


### PR DESCRIPTION
Hello! Here are some bugs that cropped up for me as was tinkering with Avian.
I'm building on Mac OS X 10.9 with Clang 3.3.1-RC2. These apply to both the master and v0.7.1 branches.

**makefile**:
- clang++ instead of clang: This errors when building the LZMA C files with 'clang -std=c++11': `error: invalid argument '-std=c++11' not allowed with 'C/ObjC'`.
- don't use `-g3` on Darwin: -g3 is typically ignored on Darwin, but for some reason, this is causing libLTO to fail when linking the bootimage-generator. Re-added for other platforms a couple lines below; plus `-g` on darwin if we're not building for speed or size.
- also sandwiched in there, `-O4` [is no longer special-cased](http://clang.llvm.org/docs/ReleaseNotes.html#new-compiler-flags) by Clang, and in fact warns/errors loudly about it. Replaced with equivalent `-O3 -flto`.
- Basically the same issue as the first, although since the rule in place here specifies only `.c` files, just use cc instead of cxx.
- Test utility won't build without this when building with LZMA.

**x86.h**
- When building for x86_64, these are the wrong headers (and in fact I get an error that they can't be found). Is there a reason to _not_ use the regular forwarding headers? 

**classpath-openjdk.cpp**
- Unused variable warning/error when building with openjdk= but not openjdk-src.

**compile.cpp**
- Unused variable warning/error.

**main.cpp**
- Clang tells me that this cannot be inlined.

... thats it for now ;)

Best, G.
