### PR TITLE
Fix NPE in Field#getAnnotation

### DIFF
--- a/classpath/java/lang/reflect/Field.java
+++ b/classpath/java/lang/reflect/Field.java
@@ -225,7 +225,7 @@ public class Field<T> extends AccessibleObject {
   }
 
   public <T extends Annotation> T getAnnotation(Class<T> class_) {
-    if (vmField.addendum.annotationTable != null) {
+    if (vmField.addendum != null && vmField.addendum.annotationTable != null) {
       Object[] table = (Object[]) vmField.addendum.annotationTable;
       for (int i = 0; i < table.length; ++i) {
         Object[] a = (Object[]) table[i];

--- a/test/Reflection.java
+++ b/test/Reflection.java
@@ -47,8 +47,16 @@ public class Reflection {
     expect(Hello.class == inner[0]);
   }
 
+  private int egads;
+
+  private static void annotations() throws Exception {
+    Field egads = Reflection.class.getDeclaredField("egads");
+    expect(egads.getAnnotation(Deprecated.class) == null);
+  }
+
   public static void main(String[] args) throws Exception {
     innerClasses();
+    annotations();
 
     Class system = Class.forName("java.lang.System");
     Field out = system.getDeclaredField("out");


### PR DESCRIPTION
When the class whose field is to be inspected has no annotations at all,
at least my javac here (1.6.0_51 on MacOSX) does not produce any class
addendum.

Therefore, let's verify that the addendum is not null before proceeding.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
