### PR TITLE
Fixed problem picking up policy jars in OpenJDK embedded build

### DIFF
--- a/makefile
+++ b/makefile
@@ -116,12 +116,12 @@ ifneq ($(openjdk),)
 			lib/security/java.policy lib/security/cacerts
 
 		local-policy = lib/security/local_policy.jar
-		ifeq ($(shell test -e "$(openjdk)/$(local-policy)" && echo found),found)
+		ifeq ($(shell test -e "$(openjdk)/jre/$(local-policy)" && echo found),found)
 			javahome-files += $(local-policy)
 		endif
 
 		export-policy = lib/security/US_export_policy.jar
-		ifeq ($(shell test -e "$(openjdk)/$(export-policy)" && echo found),found)
+		ifeq ($(shell test -e "$(openjdk)/jre/$(export-policy)" && echo found),found)
 			javahome-files += $(export-policy)
 		endif
 


### PR DESCRIPTION
The makefile had an error that resulted in local-policy.jar and US_export_policy.jar not being picked up in an OpenJDK embedded build.  The problem was that the build was looking for a `lib` folder in the jdk base folder instead of looking in `jre/lib`.
