### PR TITLE
TreeSet: fix remove() in the descending iterator

### DIFF
--- a/classpath/java/util/TreeSet.java
+++ b/classpath/java/util/TreeSet.java
@@ -57,7 +57,12 @@ public class TreeSet<T> extends AbstractSet<T> implements Collection<T> {
   }
 
   public Iterator<T> descendingIterator() {
-    ArrayList<T> iterable = new ArrayList<T>(this);
+    ArrayList<T> iterable = new ArrayList<T>(this) {
+      public T remove(int index) {
+        TreeSet.this.remove(get(index));
+        return super.remove(index);
+      }
+    };
     Collections.reverse(iterable);
     return iterable.iterator();
   }

--- a/test/Tree.java
+++ b/test/Tree.java
@@ -48,7 +48,23 @@ public class Tree {
     }
   }
 
+  private static void descendingIterator() {
+    TreeSet<Integer> t = new TreeSet<Integer>();
+    t.add(7);
+    t.add(2);
+    t.add(9);
+    t.add(2);
+    Iterator<Integer> iter = t.descendingIterator();
+    expect(9 == (int)iter.next());
+    expect(7 == (int)iter.next());
+    iter.remove();
+    expect(2 == (int)iter.next());
+    expect(!iter.hasNext());
+    isEqual(printList(t), "2, 9");
+  }
+
   public static void main(String args[]) {
+    descendingIterator();
     TreeSet<Integer> t1 = new TreeSet<Integer>(new MyCompare());
     t1.add(5); t1.add(2); t1.add(1); t1.add(8); t1.add(3);
     isEqual(printList(t1), "1, 2, 3, 5, 8");


### PR DESCRIPTION
As pointed out by Joel Dice, when we call remove() on the iterator
returned by TreeSet#descendingIterator(), we should expect the TreeSet
to remove the appropriate element.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
