### PR TITLE
fix exception wrapping for Method.invoke and static initializers

### DIFF
--- a/classpath/java/lang/ExceptionInInitializerError.java
+++ b/classpath/java/lang/ExceptionInInitializerError.java
@@ -11,11 +11,11 @@
 package java.lang;
 
 public class ExceptionInInitializerError extends Error {
-  private final Throwable cause2;
+  private final Throwable exception;
 
   public ExceptionInInitializerError(String message) {
     super(message);
-    cause2 = null;
+    exception = null;
   }
 
   public ExceptionInInitializerError() {

--- a/src/avian/classpath-common.h
+++ b/src/avian/classpath-common.h
@@ -570,10 +570,11 @@ invoke(Thread* t, object method, object instance, object args)
   unsigned returnCode = methodReturnCode(t, method);
 
   THREAD_RESOURCE0(t, {
-      if (t->exception) {
-        object exception = t->exception;
+      if (t->exception and instanceOf
+          (t, type(t, Machine::ExceptionType), t->exception))
+      {
         t->exception = makeThrowable
-          (t, Machine::InvocationTargetExceptionType, 0, 0, exception);
+          (t, Machine::InvocationTargetExceptionType, 0, 0, t->exception);
         
         set(t, t->exception, InvocationTargetExceptionTarget,
             throwableCause(t, t->exception));

--- a/src/classpath-avian.cpp
+++ b/src/classpath-avian.cpp
@@ -429,7 +429,9 @@ Avian_java_lang_reflect_Method_invoke
   object args = reinterpret_cast<object>(arguments[2]);
 
   THREAD_RESOURCE0(t, {
-      if (t->exception) {
+      if (t->exception and instanceOf
+          (t, type(t, Machine::ExceptionType), t->exception))
+      {
         object exception = t->exception;
         t->exception = makeThrowable
           (t, Machine::InvocationTargetExceptionType, 0, 0, exception);

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -4534,8 +4534,13 @@ postInitClass(Thread* t, object c)
     object exception = t->exception;
     t->exception = 0;
 
-    throwNew(t, Machine::ExceptionInInitializerErrorType,
-             static_cast<object>(0), 0, exception);
+    exception = makeThrowable
+      (t, Machine::ExceptionInInitializerErrorType, 0, 0, exception);
+        
+    set(t, exception, ExceptionInInitializerErrorException,
+        throwableCause(t, exception));
+
+    throw_(t, exception);
   } else {
     classVmFlags(t, c) &= ~(NeedInitFlag | InitFlag);
   }

--- a/test/Reflection.java
+++ b/test/Reflection.java
@@ -130,5 +130,24 @@ public class Reflection {
     expect("[Ljava.lang.Class;".equals(array[0].getClass().getName()));
     expect(Class[].class == array[0].getClass());
     expect(array.getClass().getComponentType() == array[0].getClass());
+
+    try {
+      Foo.class.getMethod("foo").invoke(null);
+      expect(false);
+    } catch (ExceptionInInitializerError e) {
+      expect(e.getCause() instanceof MyException);
+    }
   }
 }
+
+class Foo {
+  static {
+    if (true) throw new MyException();
+  }
+
+  public static void foo() {
+    // ignore
+  }
+}
+
+class MyException extends RuntimeException { }


### PR DESCRIPTION
Method.invoke should only wrap instances of Exception in
InvocationTarget, not Error.

Also, we must initialize ExceptionInInitializerError.exception when
throwing instances from the VM, since OpenJDK's
ExceptionInInitializerError.getCause uses the exception field, not the
cause field.
