### PR TITLE
fix exception wrapping for Method.invoke and static initializers

### DIFF
--- a/classpath/java/lang/ExceptionInInitializerError.java
+++ b/classpath/java/lang/ExceptionInInitializerError.java
@@ -11,11 +11,11 @@
 package java.lang;
 
 public class ExceptionInInitializerError extends Error {
-  private final Throwable cause2;
+  private final Throwable exception;
 
   public ExceptionInInitializerError(String message) {
     super(message);
-    cause2 = null;
+    exception = null;
   }
 
   public ExceptionInInitializerError() {

--- a/classpath/java/lang/reflect/Field.java
+++ b/classpath/java/lang/reflect/Field.java
@@ -84,6 +84,8 @@ public class Field<T> extends AccessibleObject {
       throw new IllegalArgumentException();
     }
 
+    Classes.initialize(vmField.class_);
+
     switch (vmField.code) {
     case ByteField:
       return Byte.valueOf
@@ -171,6 +173,8 @@ public class Field<T> extends AccessibleObject {
       throw new IllegalArgumentException();
     }
 
+    Classes.initialize(vmField.class_);
+
     switch (vmField.code) {
     case ByteField:
       setPrimitive(target, vmField.code, vmField.offset, (Byte) value);
@@ -234,6 +238,8 @@ public class Field<T> extends AccessibleObject {
     } else {
       throw new IllegalArgumentException();
     }
+
+    Classes.initialize(vmField.class_);
 
     switch (vmField.code) {
     case ByteField:

--- a/classpath/java/lang/reflect/Method.java
+++ b/classpath/java/lang/reflect/Method.java
@@ -81,6 +81,8 @@ public class Method<T> extends AccessibleObject implements Member {
       }
 
       if (arguments.length == vmMethod.parameterCount) {
+        Classes.initialize(vmMethod.class_);
+
         return invoke(vmMethod, instance, arguments);        
       } else {
         throw new ArrayIndexOutOfBoundsException();

--- a/src/avian/classpath-common.h
+++ b/src/avian/classpath-common.h
@@ -567,13 +567,14 @@ invoke(Thread* t, object method, object instance, object args)
     }
   }
 
+  initClass(t, methodClass(t, method));
+
   unsigned returnCode = methodReturnCode(t, method);
 
   THREAD_RESOURCE0(t, {
       if (t->exception) {
-        object exception = t->exception;
         t->exception = makeThrowable
-          (t, Machine::InvocationTargetExceptionType, 0, 0, exception);
+          (t, Machine::InvocationTargetExceptionType, 0, 0, t->exception);
         
         set(t, t->exception, InvocationTargetExceptionTarget,
             throwableCause(t, t->exception));

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -4534,8 +4534,13 @@ postInitClass(Thread* t, object c)
     object exception = t->exception;
     t->exception = 0;
 
-    throwNew(t, Machine::ExceptionInInitializerErrorType,
-             static_cast<object>(0), 0, exception);
+    exception = makeThrowable
+      (t, Machine::ExceptionInInitializerErrorType, 0, 0, exception);
+        
+    set(t, exception, ExceptionInInitializerErrorException,
+        throwableCause(t, exception));
+
+    throw_(t, exception);
   } else {
     classVmFlags(t, c) &= ~(NeedInitFlag | InitFlag);
   }


### PR DESCRIPTION
Method.invoke should initialize its class before invoking the method,
throwing an ExceptionInInitializerError if it fails, without wrapping
said error in an InvocationTargetException.

Also, we must initialize ExceptionInInitializerError.exception when
throwing instances from the VM, since OpenJDK's
ExceptionInInitializerError.getCause uses the exception field, not the
cause field.
