### PR TITLE
fix Android class library build breakage in Proxy.java

### DIFF
--- a/classpath/java/lang/reflect/Proxy.java
+++ b/classpath/java/lang/reflect/Proxy.java
@@ -384,7 +384,9 @@ public class Proxy {
              ConstantPool.addUtf8(pool, Classes.toString(m.spec)),
              makeInvokeCode(pool, name, m.spec, m.parameterCount,
                             m.parameterFootprint, methodTable.size())));
-          refs.add(new Method(m));
+          refs.add
+            (Classes.makeMethod
+             (SystemClassLoader.getClass(m.class_), m.offset));
         }
       }
     }


### PR DESCRIPTION
When using the Android class library, we use Avian's version of
Proxy.java, but Android's version of Method.java, so we can't use the
Avian-specific Method(VMMethod) constructor in Proxy.
