### PR TITLE
Fix the look-behind test for OpenJDK

### DIFF
--- a/test/Regex.java
+++ b/test/Regex.java
@@ -70,7 +70,7 @@ public class Regex {
     expectGroups("a|(b|c)", "a", (String)null);
     expectGroups("a|(b|c)", "c", "c");
     expectGroups("(?=a)a", "a");
-    expectGroups(".*(o)(?<=[A-Z][a-z]*)", "Hello", "o");
+    expectGroups(".*(o)(?<=[A-Z][a-z]{1,4})", "Hello", "o");
     expectNoMatch("(?!a).", "a");
     expectMatch("[\\d]", "0");
     expectMatch("\\0777", "?7");


### PR DESCRIPTION
OpenJDK's regex engine can only handle look-behinds of limited sizes.
So let's just test for that, not the unbounded one we had before (that
our own regex engine handles quite fine, though).

This fixes issue #115.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
