### PR TITLE
fix various Android test suite regressions and add more reflection tests

### DIFF
--- a/classpath/avian/Classes.java
+++ b/classpath/avian/Classes.java
@@ -441,6 +441,39 @@ public class Classes {
     return array;
   }
 
+  public static int countFields(VMClass vmClass, boolean publicOnly) {
+    int count = 0;
+    if (vmClass.fieldTable != null) {
+      for (int i = 0; i < vmClass.fieldTable.length; ++i) {
+        if ((! publicOnly)
+            || ((vmClass.fieldTable[i].flags & Modifier.PUBLIC))
+            != 0)
+        {
+          ++ count;
+        }
+      }
+    }
+    return count;
+  }
+
+  public static Field[] getFields(VMClass vmClass, boolean publicOnly) {
+    Field[] array = new Field[countFields(vmClass, publicOnly)];
+    if (vmClass.fieldTable != null) {
+      Classes.link(vmClass);
+
+      int ai = 0;
+      for (int i = 0; i < vmClass.fieldTable.length; ++i) {
+        if (((vmClass.fieldTable[i].flags & Modifier.PUBLIC) != 0)
+            || (! publicOnly))
+        {
+          array[ai++] = makeField(SystemClassLoader.getClass(vmClass), i);
+        }
+      }
+    }
+
+    return array;
+  }
+
   public static Annotation getAnnotation(ClassLoader loader, Object[] a) {
     if (a[0] == null) {
       a[0] = Proxy.newProxyInstance
@@ -469,7 +502,21 @@ public class Classes {
     }
   }
 
+  private static int index(VMMethod m) {
+    VMMethod[] table = m.class_.methodTable;
+    for (int i = 0; i < table.length; ++i) {
+      if (m == table[i]) return i;
+    }
+    throw new AssertionError();
+  }
+
+  public static Method makeMethod(VMMethod m) {
+    return makeMethod(SystemClassLoader.getClass(m.class_), index(m));
+  }
+  
   public static native Method makeMethod(Class c, int slot);
+  
+  public static native Field makeField(Class c, int slot);
 
   private static native void acquireClassLock();
 

--- a/classpath/java/lang/annotation/Annotation.java
+++ b/classpath/java/lang/annotation/Annotation.java
@@ -11,4 +11,5 @@
 package java.lang.annotation;
 
 public interface Annotation {
+  Class<? extends Annotation> annotationType();
 }

--- a/classpath/java/lang/reflect/Field.java
+++ b/classpath/java/lang/reflect/Field.java
@@ -161,6 +161,40 @@ public class Field<T> extends AccessibleObject {
     return ((Double) get(instance)).doubleValue();
   }
 
+  private boolean matchType(Object value) {
+    switch (vmField.code) {
+    case ByteField:
+      return value instanceof Byte;
+
+    case BooleanField:
+      return value instanceof Boolean;
+
+    case CharField:
+      return value instanceof Character;
+
+    case ShortField:
+      return value instanceof Short;
+
+    case IntField:
+      return value instanceof Integer;
+
+    case LongField:
+      return value instanceof Long;
+
+    case FloatField:
+      return value instanceof Float;
+
+    case DoubleField:
+      return value instanceof Double;
+
+    case ObjectField:
+      return value == null || getType().isInstance(value);
+
+    default:
+      throw new Error();
+    }
+  }
+
   public void set(Object instance, Object value)
     throws IllegalAccessException
   {
@@ -170,6 +204,10 @@ public class Field<T> extends AccessibleObject {
     } else if (Class.isInstance(vmField.class_, instance)) {
       target = instance;
     } else {
+      throw new IllegalArgumentException();
+    }
+
+    if (! matchType(value)) {
       throw new IllegalArgumentException();
     }
 
@@ -212,14 +250,7 @@ public class Field<T> extends AccessibleObject {
       break;
 
     case ObjectField:
-      if (value == null || getType().isInstance(value)) {
-        setObject(target, vmField.offset, value);
-      } else {
-        throw new IllegalArgumentException
-          ("needed " + getType() + ", got "
-           + value.getClass().getName() +
-           " when setting " + Class.getName(vmField.class_) + "." + getName());
-      }
+      setObject(target, vmField.offset, value);
       break;
 
     default:

--- a/classpath/java/lang/reflect/Proxy.java
+++ b/classpath/java/lang/reflect/Proxy.java
@@ -384,7 +384,7 @@ public class Proxy {
              ConstantPool.addUtf8(pool, Classes.toString(m.spec)),
              makeInvokeCode(pool, name, m.spec, m.parameterCount,
                             m.parameterFootprint, methodTable.size())));
-          refs.add(new Method(m));
+          refs.add(Classes.makeMethod(m));
         }
       }
     }

--- a/test/Reflection.java
+++ b/test/Reflection.java
@@ -59,6 +59,10 @@ public class Reflection {
     expect(egads.getAnnotation(Deprecated.class) == null);
   }
 
+  private Integer[] array;
+
+  private Integer integer;
+
   public static Hello<Hello<Reflection>>.World<Hello<String>> pinky;
 
   private static void genericType() throws Exception {
@@ -131,10 +135,58 @@ public class Reflection {
     expect(7.0 == (Double) Reflection.class.getMethod
            ("doubleMethod").invoke(null));
 
-    Class[][] array = new Class[][] { { Class.class } };
-    expect("[Ljava.lang.Class;".equals(array[0].getClass().getName()));
-    expect(Class[].class == array[0].getClass());
-    expect(array.getClass().getComponentType() == array[0].getClass());
+    { Class[][] array = new Class[][] { { Class.class } };
+      expect("[Ljava.lang.Class;".equals(array[0].getClass().getName()));
+      expect(Class[].class == array[0].getClass());
+      expect(array.getClass().getComponentType() == array[0].getClass());
+    }
+
+    { Reflection r = new Reflection();
+      expect(r.egads == 0);
+
+      Reflection.class.getDeclaredField("egads").set(r, 42);
+      expect(((int) Reflection.class.getDeclaredField("egads").get(r)) == 42);
+
+      Reflection.class.getDeclaredField("egads").setInt(r, 43);
+      expect(Reflection.class.getDeclaredField("egads").getInt(r) == 43);
+
+      Integer[] array = new Integer[0];
+      Reflection.class.getDeclaredField("array").set(r, array);
+      expect(Reflection.class.getDeclaredField("array").get(r) == array);
+
+      try {
+        Reflection.class.getDeclaredField("array").set(r, new Object());
+        expect(false);
+      } catch (IllegalArgumentException e) {
+        // cool
+      }
+
+      Integer integer = 45;
+      Reflection.class.getDeclaredField("integer").set(r, integer);
+      expect(Reflection.class.getDeclaredField("integer").get(r) == integer);
+
+      try {
+        Reflection.class.getDeclaredField("integer").set(r, new Object());
+        expect(false);
+      } catch (IllegalArgumentException e) {
+        // cool
+      }
+
+      try {
+        Reflection.class.getDeclaredField("integer").set
+          (new Object(), integer);
+        expect(false);
+      } catch (IllegalArgumentException e) {
+        // cool
+      }
+
+      try {
+        Reflection.class.getDeclaredField("integer").get(new Object());
+        expect(false);
+      } catch (IllegalArgumentException e) {
+        // cool
+      }
+    }
 
     try {
       Foo.class.getMethod("foo").invoke(null);
@@ -153,6 +205,22 @@ public class Reflection {
     try {
       Foo.class.getField("foo").get(null);
       expect(false);
+    } catch (NoClassDefFoundError e) {
+      // cool
+    }
+
+    try {
+      Foo.class.getField("foo").set(null, 42);
+      expect(false);
+    } catch (NoClassDefFoundError e) {
+      // cool
+    }
+
+    try {
+      Foo.class.getField("foo").set(null, new Object());
+      expect(false);
+    } catch (IllegalArgumentException e) {
+      // cool
     } catch (NoClassDefFoundError e) {
       // cool
     }


### PR DESCRIPTION
Most of these regressions were simply due to testing a lot more stuff,
esp. annotations and reflection, revealing holes in the Android
compatibility code.  There are still some holes, but at least the
suite is passing (except for a fragile test in Serialize.java which I
will open an issue for).

Sorry this is such a big commit; there was more to address than I
initially expected.
