### PR TITLE
fix FileInputStream for newer openjdk7 versions

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -2004,8 +2004,13 @@ interceptFileOperations(Thread* t, bool updateRuntimeData)
         intercept(t, fileInputStreamClass, "open", "(Ljava/lang/String;)V",
                   voidPointer(openFile), updateRuntimeData);
   
-        intercept(t, fileInputStreamClass, "read", "()I",
-                  voidPointer(readByteFromFile), updateRuntimeData);
+        if(findMethodOrNull(t, fileInputStreamClass, "read0", "()I") != 0) {
+          intercept(t, fileInputStreamClass, "read0", "()I",
+                    voidPointer(readByteFromFile), updateRuntimeData);
+        } else {
+          intercept(t, fileInputStreamClass, "read", "()I",
+                    voidPointer(readByteFromFile), updateRuntimeData);
+        }
   
         intercept(t, fileInputStreamClass, "readBytes", "([BII)I",
                   voidPointer(readBytesFromFile), updateRuntimeData);


### PR DESCRIPTION
This fixes #76.

I've tested this on both a newer openjdk-src build (when cherry-picked on top of the code for #129), and a normal openjdk (7u45) build - so both branches are good.
