### PR TITLE
Specify formatting style via .clang-format config file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+---
+BasedOnStyle:  Chromium
+IndentCaseLabels: false
+BreakBeforeBraces: Stroustrup
+AllowShortFunctionsOnASingleLine: false
+BreakBeforeBinaryOperators: true
+...


### PR DESCRIPTION
This adds an initial c++ style specification in the form of a .clang-format file.

By default, the clang-format tool will look for this file in one of the parent directories (recursively) of the file being formatted.

I've verified that the clang-format plugins for both sublime text (https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-sublime.py) and for emacs (https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format.el) work out of the box, and detect this configuration.
