### PR TITLE
Adding more java.util.concurrent interfaces that were missed previously.

### DIFF
--- a/classpath/java/util/concurrent/BlockingQueue.java
+++ b/classpath/java/util/concurrent/BlockingQueue.java
@@ -1,0 +1,20 @@
+package java.util.concurrent;
+
+import java.util.Collection;
+import java.util.Queue;
+
+public interface BlockingQueue<T> extends Queue<T> {
+  public void put(T e) throws InterruptedException;
+  
+  public boolean offer(T e, long timeout, TimeUnit unit) throws InterruptedException;
+  
+  public T take() throws InterruptedException;
+  
+  public T poll(long timeout, TimeUnit unit) throws InterruptedException;
+  
+  public int remainingCapacity();
+  
+  public int drainTo(Collection<? super T> c);
+  
+  public int drainTo(Collection<? super T> c, int maxElements);
+}

--- a/classpath/java/util/concurrent/CompletionService.java
+++ b/classpath/java/util/concurrent/CompletionService.java
@@ -1,0 +1,13 @@
+package java.util.concurrent;
+
+public interface CompletionService<T> {
+  public Future<T> submit(Callable<T> task);
+  
+  public Future<T> submit(Runnable task, T result);
+  
+  public Future<T> take() throws InterruptedException;
+  
+  public Future<T> poll();
+  
+  public Future<T> poll(long timeout, TimeUnit unit) throws InterruptedException;
+}

--- a/classpath/java/util/concurrent/RunnableFuture.java
+++ b/classpath/java/util/concurrent/RunnableFuture.java
@@ -1,0 +1,5 @@
+package java.util.concurrent;
+
+public interface RunnableFuture<T> extends Runnable, Future<T> {
+  // nothing added to interface
+}

--- a/classpath/java/util/concurrent/ScheduledExecutorService.java
+++ b/classpath/java/util/concurrent/ScheduledExecutorService.java
@@ -1,0 +1,19 @@
+package java.util.concurrent;
+
+public interface ScheduledExecutorService extends ExecutorService {
+  public ScheduledFuture<?> schedule(Runnable command,
+                                     long delay, TimeUnit unit);
+  
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable,
+                                         long delay, TimeUnit unit);
+  
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable command,
+                                                long initialDelay,
+                                                long period,
+                                                TimeUnit unit);
+  
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command,
+                                                   long initialDelay,
+                                                   long delay,
+                                                   TimeUnit unit);
+}

--- a/classpath/java/util/concurrent/ThreadFactory.java
+++ b/classpath/java/util/concurrent/ThreadFactory.java
@@ -1,0 +1,5 @@
+package java.util.concurrent;
+
+public interface ThreadFactory {
+  public Thread newThread(Runnable r);
+}


### PR DESCRIPTION
These are some more interfaces, hopefully to lay way for the following implementations:
java.util.concurrent.ExecutorCompletionService
java.util.concurrent.FutureTask
java.util.concurrent.locks.LockSupport

Just figured I would keep doing little bits at a time.
