### PR TITLE
add Thread.run() to vm.pro

### DIFF
--- a/vm.pro
+++ b/vm.pro
@@ -98,6 +98,7 @@
 
 -keepclassmembers class java.lang.Thread {
    private static void run(java.lang.Thread);
+   public void run();
  }
 
 # when continuations are enabled, the VM may call these methods by name:


### PR DESCRIPTION
This is necessary to ensure multithreaded Android-classpath-based
ProGuarded builds do not fail with NoSuchMethodErrors.
