### PR TITLE
add "-lIphlpapi" to embedding example link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ __on Windows:__
     $ dlltool -z hello.def *.o
     $ dlltool -d hello.def -e hello.exp
     $ gcc hello.exp *.o -L../../win32/lib -lmingwthrd -lm -lz -lws2_32 \
-        -mwindows -mconsole -o hello.exe
+        -lIphlpapi -mwindows -mconsole -o hello.exe
     $ strip --strip-all hello.exe
 
 Embedding with ProGuard and a Boot Image


### PR DESCRIPTION
This is needed to allow the link to succeed when doing an openjdk-src
build on Windows.
