### PR TITLE
fix #172, regression in compiling shift operations

### DIFF
--- a/src/codegen/target/x86/operations.cpp
+++ b/src/codegen/target/x86/operations.cpp
@@ -1280,7 +1280,8 @@ void shiftLeftRR(Context* c, UNUSED unsigned aSize, lir::Register* a,
 
     ResolvedPromise promise(32);
     lir::Constant constant(&promise);
-    compareCR(c, aSize, &constant, aSize, &cx);
+    compareCR(c, vm::TargetBytesPerWord, &constant, vm::TargetBytesPerWord,
+              &cx);
 
     opcode(c, 0x7c); //jl
     c->code.append(2 + 2);
@@ -1324,7 +1325,8 @@ void shiftRightRR(Context* c, UNUSED unsigned aSize, lir::Register* a,
 
     ResolvedPromise promise(32);
     lir::Constant constant(&promise);
-    compareCR(c, aSize, &constant, aSize, &cx);
+    compareCR(c, vm::TargetBytesPerWord, &constant, vm::TargetBytesPerWord,
+              &cx);
 
     opcode(c, 0x7c); //jl
     c->code.append(2 + 3);
@@ -1371,7 +1373,8 @@ void unsignedShiftRightRR(Context* c, UNUSED unsigned aSize, lir::Register* a,
 
     ResolvedPromise promise(32);
     lir::Constant constant(&promise);
-    compareCR(c, aSize, &constant, aSize, &cx);
+    compareCR(c, vm::TargetBytesPerWord, &constant, vm::TargetBytesPerWord,
+              &cx);
 
     opcode(c, 0x7c); //jl
     c->code.append(2 + 2);


### PR DESCRIPTION
Before d5c1a094ca116f8f54eca7a3ce24575b9def298c, we generated ir for shift operations (shl/shr/ushr, etc) where the size of the first operand was TargetBytesPerWord, instead of the "true" size.  Instead of directly reverting that accidental change, we should make the codegen portion tolerant of the real operand sizes.
