### PR TITLE
split out ffi::call from System

### DIFF
--- a/include/avian/system/system.h
+++ b/include/avian/system/system.h
@@ -128,9 +128,7 @@ class System : public avian::util::Aborter {
 
   virtual Status visit(Thread* thread, Thread* target,
                        ThreadVisitor* visitor) = 0;
-  virtual uint64_t call(void* function, uintptr_t* arguments, uint8_t* types,
-                        unsigned count, unsigned size,
-                        unsigned returnType) = 0;
+
   virtual Status map(Region**, const char* name) = 0;
   virtual FileType stat(const char* name, unsigned* length) = 0;
   virtual Status open(Directory**, const char* name) = 0;

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -7426,13 +7426,12 @@ invokeNativeSlow(MyThread* t, object method, void* function)
     t->checkpoint->noThrow = true;
     THREAD_RESOURCE(t, bool, noThrow, t->checkpoint->noThrow = noThrow);
 
-    result = t->m->system->call
-      (function,
-       RUNTIME_ARRAY_BODY(args),
-       RUNTIME_ARRAY_BODY(types),
-       count,
-       footprint * BytesPerWord,
-       returnType);
+    result = vm::dynamicCall(function,
+                             RUNTIME_ARRAY_BODY(args),
+                             RUNTIME_ARRAY_BODY(types),
+                             count,
+                             footprint * BytesPerWord,
+                             returnType);
   }
 
   if (methodFlags(t, method) & ACC_SYNCHRONIZED) {

--- a/src/interpret.cpp
+++ b/src/interpret.cpp
@@ -597,13 +597,12 @@ invokeNativeSlow(Thread* t, object method, void* function)
     t->checkpoint->noThrow = true;
     THREAD_RESOURCE(t, bool, noThrow, t->checkpoint->noThrow = noThrow);
 
-    result = t->m->system->call
-      (function,
-       RUNTIME_ARRAY_BODY(args),
-       RUNTIME_ARRAY_BODY(types),
-       count,
-       footprint * BytesPerWord,
-       returnType);
+    result = vm::dynamicCall(function,
+                             RUNTIME_ARRAY_BODY(args),
+                             RUNTIME_ARRAY_BODY(types),
+                             count,
+                             footprint * BytesPerWord,
+                             returnType);
   }
 
   if (DebugRun) {

--- a/src/system/posix.cpp
+++ b/src/system/posix.cpp
@@ -745,12 +745,6 @@ class MySystem: public System {
 #endif // not  __APPLE__
   }
 
-  virtual uint64_t call(void* function, uintptr_t* arguments, uint8_t* types,
-                        unsigned count, unsigned size, unsigned returnType)
-  {
-    return dynamicCall(function, arguments, types, count, size, returnType);
-  }
-
   virtual Status map(System::Region** region, const char* name) {
     Status status = 1;
 

--- a/src/system/windows.cpp
+++ b/src/system/windows.cpp
@@ -730,12 +730,6 @@ class MySystem: public System {
 #endif
   }
 
-  virtual uint64_t call(void* function, uintptr_t* arguments, uint8_t* types,
-                        unsigned count, unsigned size, unsigned returnType)
-  {
-    return dynamicCall(function, arguments, types, count, size, returnType);
-  }
-
   virtual Status map(System::Region** region, const char* name) {
     Status status = 1;
     size_t nameLen = strlen(name) * 2;


### PR DESCRIPTION
System::call was pointlessly dynamically dispatched, as both implementations did exactly the same thing (which actually did vary based on the architecture).  Also, it made for a needless dependency on the assembly code.

If you have suggestions on better places to put this, I'm all ears.
