### PR TITLE
remove redundant decrement in ZipFile.getInputStream inner class

### DIFF
--- a/classpath/java/util/zip/ZipFile.java
+++ b/classpath/java/util/zip/ZipFile.java
@@ -103,11 +103,9 @@ public class ZipFile {
         int remaining = uncompressedSize(window, pointer);
 
         public int read() throws IOException {
-          int c = super.read();
-          if (c >= 0) {
-            -- remaining;
-          }
-          return c;
+          byte[] buffer = new byte[1];
+          int c = read(buffer);
+          return (c < 0 ? c : (buffer[0] & 0xFF));
         }
 
         public int read(byte[] buffer) throws IOException {


### PR DESCRIPTION
We were decrementing the "remaining" field twice for each byte read
using the no-arg read method, which resulted in available() returning
a value that was too small.
