### PR TITLE
fix Class.getDeclaredMethods

### DIFF
--- a/classpath/avian/ClassAddendum.java
+++ b/classpath/avian/ClassAddendum.java
@@ -13,7 +13,14 @@ package avian;
 public class ClassAddendum extends Addendum {
   public Object[] interfaceTable;
   public InnerClassReference[] innerClassTable;
-  public Object[] methodTable;
+  /**
+   * If this value is negative, all the methods in VMClass.methodTable
+   * were declared in that class.  Otherwise, only the first
+   * declaredMethodCount methods in that table were declared in that
+   * class, while the rest were declared in interfaces implemented or
+   * extended by that class.
+   */
+  public int declaredMethodCount;
   public Object enclosingClass;
   public Object enclosingMethod;
 }

--- a/classpath/avian/VMClass.java
+++ b/classpath/avian/VMClass.java
@@ -24,6 +24,15 @@ public class VMClass {
   public Object[] interfaceTable;
   public VMMethod[] virtualTable;
   public VMField[] fieldTable;
+  /**
+   * Methods declared in this class, plus any abstract virtual methods
+   * inherited from implemented or extended interfaces.  If addendum
+   * is non-null and addendum.declaredMethodCount is non-negative,
+   * then the first addendum.declaredMethodCount methods are declared
+   * methods, while the rest are abstract virtual methods.  If
+   * addendum is null or addendum.declaredMethodCount is negative, all
+   * are declared methods.
+   */
   public VMMethod[] methodTable;
   public ClassAddendum addendum;
   public Object staticTable;

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -1123,7 +1123,7 @@ getClassAddendum(Thread* t, object class_, object pool)
   if (addendum == 0) {
     PROTECT(t, class_);
 
-    addendum = makeClassAddendum(t, pool, 0, 0, 0, 0, 0, 0, 0);
+    addendum = makeClassAddendum(t, pool, 0, 0, 0, 0, -1, 0, 0);
     set(t, class_, ClassAddendum, addendum);
   }
   return addendum;
@@ -2206,12 +2206,14 @@ parseMethodTable(Thread* t, Stream& s, object class_, object pool)
     if (abstractVirtuals) {
       PROTECT(t, vtable);
 
-      object addendum = getClassAddendum(t, class_, pool);
-      set(t, addendum, ClassAddendumMethodTable,
-          classMethodTable(t, class_));
+      object originalMethodTable = classMethodTable(t, class_);
+      PROTECT(t, originalMethodTable);
 
       unsigned oldLength = classMethodTable(t, class_) ?
         arrayLength(t, classMethodTable(t, class_)) : 0;
+
+      object addendum = getClassAddendum(t, class_, pool);
+      classAddendumDeclaredMethodCount(t, addendum) = oldLength;
 
       object newMethodTable = makeArray
         (t, oldLength + listSize(t, abstractVirtuals));

--- a/test/Reflection.java
+++ b/test/Reflection.java
@@ -241,6 +241,8 @@ public class Reflection {
     expect(avian.TestReflection.get(Baz.class.getField("foo"), new Baz())
            .equals(42));
     expect((Baz.class.getModifiers() & Modifier.PUBLIC) == 0);
+
+    expect(B.class.getDeclaredMethods().length == 0);
   }
 
   protected static class Baz {
@@ -263,3 +265,9 @@ class Foo {
 }
 
 class MyException extends RuntimeException { }
+
+interface A {
+  void foo();
+}
+
+interface B extends A { }


### PR DESCRIPTION
getDeclaredMethods was returning methods which were inherited from a
superclass or superinterface but not (re)declared in the class itself,
due to the VM's internal use of VMClass.methodTable differing from its
role in reflection.  For reflection, we must use
ClassAddendum.methodTable if it's present (i.e. if it differs from
VMClass.methodTable).

This fixes https://github.com/ReadyTalk/avian/issues/185
