### PR TITLE
move Unsafe.get{Object|Int}Volatile from classpath-openjdk.cpp to builti...

### DIFF
--- a/classpath/sun/misc/Unsafe.java
+++ b/classpath/sun/misc/Unsafe.java
@@ -46,6 +46,8 @@ public final class Unsafe {
 
   public native void putDouble(long address, double x);
 
+  public native int getIntVolatile(Object o, long offset);
+
   public native void putIntVolatile(Object o, long offset, int x);
 
   public native long getLongVolatile(Object o, long offset);
@@ -63,6 +65,8 @@ public final class Unsafe {
   public native void putObjectVolatile(Object o, long offset, Object x);
 
   public native void putOrderedObject(Object o, long offset, Object x);
+
+  public native Object getObjectVolatile(Object o, long offset);
 
   public native long getAddress(long address);
 

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -724,6 +724,18 @@ Avian_sun_misc_Unsafe_putOrderedObject
 }
 
 extern "C" AVIAN_EXPORT int64_t JNICALL
+Avian_sun_misc_Unsafe_getObjectVolatile
+(Thread*, object, uintptr_t* arguments)
+{
+  object o = reinterpret_cast<object>(arguments[1]);
+  int64_t offset; memcpy(&offset, arguments + 2, 8);
+  
+  uintptr_t value = fieldAtOffset<uintptr_t>(o, offset);
+  loadMemoryBarrier();
+  return value;
+}
+
+extern "C" AVIAN_EXPORT int64_t JNICALL
 Avian_sun_misc_Unsafe_compareAndSwapObject
 (Thread* t, object, uintptr_t* arguments)
 {
@@ -914,6 +926,18 @@ Avian_sun_misc_Unsafe_putOrderedInt
 (Thread* t, object method, uintptr_t* arguments)
 {
   Avian_sun_misc_Unsafe_putIntVolatile(t, method, arguments);
+}
+
+extern "C" AVIAN_EXPORT int64_t JNICALL
+Avian_sun_misc_Unsafe_getIntVolatile
+(Thread*, object, uintptr_t* arguments)
+{
+  object o = reinterpret_cast<object>(arguments[1]);
+  int64_t offset; memcpy(&offset, arguments + 2, 8);
+
+  int32_t result = fieldAtOffset<int32_t>(o, offset);
+  loadMemoryBarrier();
+  return result;
 }
 
 extern "C" AVIAN_EXPORT void JNICALL

--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -2641,22 +2641,6 @@ Avian_sun_misc_Unsafe_getFloat__Ljava_lang_Object_2J
 }
 
 extern "C" AVIAN_EXPORT int64_t JNICALL
-Avian_sun_misc_Unsafe_getIntVolatile
-(Thread* t, object, uintptr_t* arguments)
-{
-  object o = reinterpret_cast<object>(arguments[1]);
-  int64_t offset; memcpy(&offset, arguments + 2, 8);
-
-  // avoid blocking the VM if this is being called in a busy loop
-  PROTECT(t, o);
-  { ENTER(t, Thread::IdleState); }
-
-  int32_t result = fieldAtOffset<int32_t>(o, offset);
-  loadMemoryBarrier();
-  return result;
-}
-
-extern "C" AVIAN_EXPORT int64_t JNICALL
 Avian_sun_misc_Unsafe_getLong__Ljava_lang_Object_2J
 (Thread*, object, uintptr_t* arguments)
 {
@@ -2767,22 +2751,6 @@ Avian_sun_misc_Unsafe_putLong__Ljava_lang_Object_2JJ
   int64_t value; memcpy(&value, arguments + 4, 8);
 
   fieldAtOffset<int64_t>(o, offset) = value;
-}
-
-extern "C" AVIAN_EXPORT int64_t JNICALL
-Avian_sun_misc_Unsafe_getObjectVolatile
-(Thread* t, object, uintptr_t* arguments)
-{
-  object o = reinterpret_cast<object>(arguments[1]);
-  int64_t offset; memcpy(&offset, arguments + 2, 8);
-
-  // avoid blocking the VM if this is being called in a busy loop
-  PROTECT(t, o);
-  { ENTER(t, Thread::IdleState); }
-  
-  uintptr_t value = fieldAtOffset<uintptr_t>(o, offset);
-  loadMemoryBarrier();
-  return value;
 }
 
 extern "C" AVIAN_EXPORT int64_t JNICALL


### PR DESCRIPTION
...n.cpp

This makes them available in all class libraries, not just the OpenJDK
library.  Note that I've also removed the unecessary idle statements,
per ab4adef.

Fixes #187.
