### PR TITLE
fix broken Class.getDeclar{ed|ing}Classes implementations

### DIFF
--- a/src/avian/classpath-common.h
+++ b/src/avian/classpath-common.h
@@ -731,7 +731,7 @@ getDeclaringClass(Thread* t, object c)
     if (table) {
       for (unsigned i = 0; i < arrayLength(t, table); ++i) {
         object reference = arrayBody(t, table, i);
-        if (strcmp
+        if (innerClassReferenceOuter(t, reference) and strcmp
             (&byteArrayBody(t, innerClassReferenceInner(t, reference), 0),
              &byteArrayBody(t, className(t, c), 0)) == 0)
         {

--- a/test/Reflection.java
+++ b/test/Reflection.java
@@ -243,6 +243,12 @@ public class Reflection {
     expect((Baz.class.getModifiers() & Modifier.PUBLIC) == 0);
 
     expect(B.class.getDeclaredMethods().length == 0);
+
+    new Runnable() {
+      public void run() {
+        expect(getClass().getDeclaringClass() == null);
+      }
+    }.run();
   }
 
   protected static class Baz {


### PR DESCRIPTION
classpath-common.h's getDeclaringClass was trying to look up
non-existing classes, which led to an abort, and I don't even know
what Class.getDeclaredClasses was trying to do, but it was ugly and
wrong.

Fixes #197
