### PR TITLE
ensure ClassLoader.getPackage works with all class libraries

### DIFF
--- a/classpath/avian/SystemClassLoader.java
+++ b/classpath/avian/SystemClassLoader.java
@@ -74,6 +74,21 @@ public class SystemClassLoader extends ClassLoader {
     return null;
   }
 
+  protected Package getPackage(String name) {
+    Package p = super.getPackage(name);
+    if (p == null) {
+      String source = getPackageSource(name);
+      if (source != null) {
+        // todo: load attributes from JAR manifest
+        definePackage(name, null, null, null, null, null, null, null);
+      }
+    }
+
+    return super.getPackage(name);
+  }
+
+  protected static native String getPackageSource(String name);
+
   // OpenJDK's java.lang.ClassLoader.getResource makes use of
   // sun.misc.Launcher to load bootstrap resources, which is not
   // appropriate for the Avian build, so we override it to ensure we

--- a/classpath/java/lang/Class.java
+++ b/classpath/java/lang/Class.java
@@ -559,8 +559,7 @@ public final class Class <T> implements Type, AnnotatedElement {
       String name = getCanonicalName();
       int index = name.lastIndexOf('.');
       if (index >= 0) {
-        return new Package(name.substring(0, index),
-                           null, null, null, null, null, null, null, null);
+        return getClassLoader().getPackage(name.substring(0, index));
       } else {
         return null;
       }

--- a/classpath/java/lang/ClassLoader.java
+++ b/classpath/java/lang/ClassLoader.java
@@ -17,9 +17,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Map;
+import java.util.HashMap;
 
 public abstract class ClassLoader {
   private final ClassLoader parent;
+  private Map<String, Package> packages;
 
   protected ClassLoader(ClassLoader parent) {
     if (parent == null) {
@@ -32,6 +35,45 @@ public abstract class ClassLoader {
   protected ClassLoader() {
     this(getSystemClassLoader());
   }
+
+  private Map<String, Package> packages() {
+    if (packages == null) {
+      packages = new HashMap();
+    }
+    return packages;
+  }
+
+  protected Package getPackage(String name) {
+    synchronized (this) {
+      return packages().get(name);
+    }
+  }
+
+  protected Package[] getPackages() {
+    synchronized (this) {
+      return packages().values().toArray(new Package[packages().size()]);
+    }
+  }
+
+  protected Package definePackage(String name,
+                                  String specificationTitle,
+                                  String specificationVersion,
+                                  String specificationVendor,
+                                  String implementationTitle,
+                                  String implementationVersion,
+                                  String implementationVendor,
+                                  URL sealBase)
+    {
+      Package p = new Package
+        (name, implementationTitle, implementationVersion,
+         implementationVendor, specificationTitle, specificationVersion,
+         specificationVendor, sealBase, this);
+
+      synchronized (this) {
+        packages().put(name, p);
+        return p;
+      }
+    }
 
   public static ClassLoader getSystemClassLoader() {
     return ClassLoader.class.getClassLoader();

--- a/src/avian/machine.h
+++ b/src/avian/machine.h
@@ -1577,9 +1577,6 @@ class Classpath {
   virtual const char*
   bootClasspath() = 0;
 
-  virtual void
-  updatePackageMap(Thread* t, object class_) = 0;
-
   virtual object
   makeDirectByteBuffer(Thread* t, void* p, jlong capacity) = 0;
 

--- a/src/classpath-avian.cpp
+++ b/src/classpath-avian.cpp
@@ -133,12 +133,6 @@ class MyClasspath : public Classpath {
     return AVIAN_CLASSPATH;
   }
 
-  virtual void
-  updatePackageMap(Thread*, object)
-  {
-    // ignore
-  }
-
   virtual object
   makeDirectByteBuffer(Thread* t, void* p, jlong capacity)
   {

--- a/test/Reflection.java
+++ b/test/Reflection.java
@@ -249,6 +249,9 @@ public class Reflection {
         expect(getClass().getDeclaringClass() == null);
       }
     }.run();
+
+    expect(avian.testing.annotations.Test.class.getPackage().getName().equals
+           ("avian.testing.annotations"));
   }
 
   protected static class Baz {


### PR DESCRIPTION
There's more work to do to derive all the properties of a given class
from its code source (e.g. JAR file), but this at least ensures that
ClassLoader.getPackage will actually return something non-null when
appropriate.

Fixes #203
