### PR TITLE
fix build on mingw

### DIFF
--- a/classpath/java-io.cpp
+++ b/classpath/java-io.cpp
@@ -129,7 +129,7 @@ inline bool
 exists(string_t path)
 {
 #ifdef PLATFORM_WINDOWS
-  return GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES;
+  return GetFileAttributesW(path) != INVALID_FILE_ATTRIBUTES;
 #else
   STRUCT_STAT s;
   return STAT(path, &s) == 0;


### PR DESCRIPTION
It's beyond me why mingw isn't recognizing the UNICODE macro at the top of the file.  I even went as far as looking at the _mingw.h (where __AW is defined, which should be selecting either -A or -W suffixed functions, based on UNICODE).  Inspecting the gcc -E output, it looks like all the requisite macros are defined / undefined properly to allow us to take the -W branch of the `#if`.  I'm stumped

The workaround is to add an explicit -W suffix to the method call in question.
