### PR TITLE
fix OpenJDK and Android build regression

### DIFF
--- a/makefile
+++ b/makefile
@@ -1330,6 +1330,7 @@ ifneq ($(classpath),avian)
 		$(classpath-src)/avian/AnnotationInvocationHandler.java \
 		$(classpath-src)/avian/Assembler.java \
 		$(classpath-src)/avian/Callback.java \
+		$(classpath-src)/avian/Cell.java \
 		$(classpath-src)/avian/ClassAddendum.java \
 		$(classpath-src)/avian/InnerClassReference.java \
 		$(classpath-src)/avian/Classes.java \


### PR DESCRIPTION
c2bfba9 introduced a regression such that building against a non-Avian
class library failed due to avian.Cell not being added to the library.
Since avian.Continuations depends on that class, the build broke.
