### PR TITLE
fix Java 6 build

### DIFF
--- a/classpath/java/nio/channels/SocketChannel.java
+++ b/classpath/java/nio/channels/SocketChannel.java
@@ -185,9 +185,10 @@ public class SocketChannel extends SelectableChannel
       }
 
       if (a == null) {
-        bind(socket, 0, 0);
+        SocketChannel.bind(socket, 0, 0);
       } else {
-        bind(socket, a.getAddress().getRawAddress(), a.getPort());
+        SocketChannel.bind
+          (socket, a.getAddress().getRawAddress(), a.getPort());
       }
     }
   }


### PR DESCRIPTION
Java 6's javac is not as smart as Java 7's when it comes to calling
overloaded methods from an inner class, so we have to be more
explicit.

I'd like to point out that the first four characters of the commit hash are "d00d", which is cool.
