### PR TITLE
disable LTO by default

### DIFF
--- a/makefile
+++ b/makefile
@@ -1054,15 +1054,9 @@ ifeq ($(mode),stress-major)
 endif
 ifeq ($(mode),fast)
 	optimization-cflags = $(cflags_fast) -DNDEBUG
-	ifeq ($(use-lto),)
-		use-lto = true
-	endif
 endif
 ifeq ($(mode),small)
 	optimization-cflags = $(cflags_small) -DNDEBUG
-	ifeq ($(use-lto),)
-		use-lto = true
-	endif
 endif
 
 ifeq ($(use-lto),true)


### PR DESCRIPTION
The -flto flag slows down linking dramatically without providing a
noticeable improvement in speed or size.  Rather than take the
build-time hit every time we rebuild, let's only do it when it's
explicitly requested.
