### PR TITLE
initialize class in JNIEnv::FindClass

### DIFF
--- a/src/jnienv.cpp
+++ b/src/jnienv.cpp
@@ -349,12 +349,16 @@ findClass(Thread* t, uintptr_t* arguments)
 
   object caller = getCaller(t, 0);
 
-  return reinterpret_cast<uint64_t>
-    (makeLocalReference
-     (t, getJClass
-      (t, resolveClass
-       (t, caller ? classLoader(t, methodClass(t, caller))
-        : root(t, Machine::AppLoader), n))));
+  object c = resolveClass(t,
+                          caller ? classLoader(t, methodClass(t, caller))
+                                 : root(t, Machine::AppLoader),
+                          n);
+
+  PROTECT(t, c);
+
+  initClass(t, c);
+
+  return reinterpret_cast<uint64_t>(makeLocalReference(t, getJClass(t, c)));
 }
 
 jclass JNICALL


### PR DESCRIPTION
Although the JNI reference documentation does not mention it,
FindClass should initialize the class before it returns it.  That's
what HotSpot does, and that's what we have to do too.

In particular, OpenJDK's
Java_java_net_Inet6AddressImpl_lookupAllHostAddr relies on
Inet6Address's static initializer being run when it is resolved using
FindClass, or else it will crash.
