### PR TITLE
fix incorrect EXPORT definition for Windows/x86_64 in boot-javahome.cpp

### DIFF
--- a/src/boot-javahome.cpp
+++ b/src/boot-javahome.cpp
@@ -8,22 +8,13 @@
    There is NO WARRANTY for this software.  See license.txt for
    details. */
 
-#ifdef _MSC_VER
-
-typedef unsigned char uint8_t;
-
-#else
-#  include "stdint.h"
-#endif
+#include "avian/common.h"
 
 #ifdef BOOT_JAVAHOME
 
 #if (! defined __x86_64__) && ((defined __MINGW32__) || (defined _MSC_VER))
-#  define EXPORT __declspec(dllexport)
 #  define SYMBOL(x) binary_javahome_jar_##x
 #else
-#  define EXPORT __attribute__ ((visibility("default"))) \
-  __attribute__ ((used))
 #  define SYMBOL(x) _binary_javahome_jar_##x
 #endif
 
@@ -32,7 +23,7 @@ extern "C" {
   extern const uint8_t SYMBOL(start)[];
   extern const uint8_t SYMBOL(end)[];
 
-  EXPORT const uint8_t*
+  AVIAN_EXPORT const uint8_t*
   javahomeJar(unsigned* size)
   {
     *size = SYMBOL(end) - SYMBOL(start);

--- a/src/boot.cpp
+++ b/src/boot.cpp
@@ -8,28 +8,13 @@
    There is NO WARRANTY for this software.  See license.txt for
    details. */
 
-#include "stdlib.h"
+#include <stdlib.h>
 
-#ifdef _MSC_VER
-
-typedef unsigned char uint8_t;
-
-#else // not _MSC_VER
-
-#  include "stdint.h"
+#include "avian/common.h"
 
 // since we aren't linking against libstdc++, we must implement this
 // ourselves:
 extern "C" void __cxa_pure_virtual(void) { abort(); }
-
-#endif // not _MSC_VER
-
-#if (defined __MINGW32__) || (defined _MSC_VER)
-#  define EXPORT __declspec(dllexport)
-#else
-#  define EXPORT __attribute__ ((visibility("default"))) \
-  __attribute__ ((used))
-#endif
 
 #ifdef BOOT_IMAGE
 
@@ -46,7 +31,7 @@ extern "C" {
   extern const uint8_t BOOTIMAGE_SYMBOL(start)[];
   extern const uint8_t BOOTIMAGE_SYMBOL(end)[];
 
-  EXPORT const uint8_t*
+  AVIAN_EXPORT const uint8_t*
   bootimageBin(unsigned* size)
   {
     *size = BOOTIMAGE_SYMBOL(end) - BOOTIMAGE_SYMBOL(start);
@@ -56,7 +41,7 @@ extern "C" {
   extern const uint8_t CODEIMAGE_SYMBOL(start)[];
   extern const uint8_t CODEIMAGE_SYMBOL(end)[];
 
-  EXPORT const uint8_t*
+  AVIAN_EXPORT const uint8_t*
   codeimageBin(unsigned* size)
   {
     *size = CODEIMAGE_SYMBOL(end) - CODEIMAGE_SYMBOL(start);
@@ -82,7 +67,7 @@ extern "C" {
   extern const uint8_t SYMBOL(start)[];
   extern const uint8_t SYMBOL(end)[];
 
-  EXPORT const uint8_t*
+  AVIAN_EXPORT const uint8_t*
   classpathJar(unsigned* size)
   {
     *size = SYMBOL(end) - SYMBOL(start);

--- a/src/embedded-loader.cpp
+++ b/src/embedded-loader.cpp
@@ -13,24 +13,15 @@
 #include <stdint.h>
 
 #include "avian/embed.h"
+#include "avian/common.h"
 #include "jni.h"
-
-#if (defined __MINGW32__) || (defined _MSC_VER)
-#  define EXPORT __declspec(dllexport)
-#  ifdef _MSC_VER
-#    define not !
-#  endif
-#else
-#  define EXPORT __attribute__ ((visibility("default"))) \
-  __attribute__ ((used))
-#endif
 
 extern "C" {
   // since we aren't linking against libstdc++, we must implement this   
   // ourselves:
   void __cxa_pure_virtual(void) { abort(); }
 
-  EXPORT const uint8_t*
+  AVIAN_EXPORT const uint8_t*
   bootJar(unsigned* size)
   {
     if(HRSRC hResInfo = FindResourceW(NULL, RESID_BOOT_JAR, reinterpret_cast<LPCWSTR>(RT_RCDATA)))


### PR DESCRIPTION
We should define EXPORT to be __declspec(dllexport) on Windows
regardless of architecture, not just non-x86_64 arches.  This fixes
errors to to embedded JAVA_HOME files not being found in openjdk-src
builds, e.g. lib/currency.data.
