### PR TITLE
fix Android bootimage build

### DIFF
--- a/src/tools/type-generator/main.cpp
+++ b/src/tools/type-generator/main.cpp
@@ -1839,6 +1839,7 @@ writeMap(Output* out, Object* type)
     Object* m = it.next();
 
     if (it.sawSuperclassBoundary) {
+      it.sawSuperclassBoundary = false;
       out->write("Type_pad, ");
     }
 


### PR DESCRIPTION
bb86500 was a step in the right direction, but there was a bug that
caused Type_pad fields to be inserted between every other field in for
a derived class when type-maps.cpp was generated, and this led to
miscompilation of e.g. Android's
java.lang.reflect.Constructor.getModifiers.
