### PR TITLE
add expect call to ensure tryAllocateExecutable actually succeeds

### DIFF
--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -9095,6 +9095,9 @@ class MyProcessor: public Processor {
     if (codeAllocator.memory.begin() == 0) {
       codeAllocator.memory.items = static_cast<uint8_t*>(
           s->tryAllocateExecutable(ExecutableAreaSizeInBytes));
+
+      expect(t, codeAllocator.memory.items);
+
       codeAllocator.memory.count = ExecutableAreaSizeInBytes;
     }
 #endif


### PR DESCRIPTION
For some reason, running Avian under the SVN version of Valgrind
caused mmap to fail, which caused tryAllocateExecutable to return a
null pointer, which led to a non-obvious crash later on.  Adding an
expect to check the result immediately will at least make it obvious
what went wrong.
