### PR TITLE
Small change to make these two structures implement RandomAccess

### DIFF
--- a/classpath/java/util/ArrayList.java
+++ b/classpath/java/util/ArrayList.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-public class ArrayList<T> extends AbstractList<T> implements java.io.Serializable {
+public class ArrayList<T> extends AbstractList<T> implements java.io.Serializable, RandomAccess {
   private static final int MinimumCapacity = 16;
 
   private Object[] array;

--- a/classpath/java/util/RandomAccess.java
+++ b/classpath/java/util/RandomAccess.java
@@ -11,4 +11,6 @@
 package java.util;
 
 public interface RandomAccess {
+  /* nothing added here, this interface just indicates a 
+   * structure is efficient to access via index's directly.*/
 }

--- a/classpath/java/util/Vector.java
+++ b/classpath/java/util/Vector.java
@@ -10,7 +10,7 @@
 
 package java.util;
 
-public class Vector<T> extends AbstractList<T> implements java.io.Serializable, Cloneable {
+public class Vector<T> extends AbstractList<T> implements java.io.Serializable, Cloneable, RandomAccess {
   private final ArrayList<T> list;
 
   public Vector(int capacity) {


### PR DESCRIPTION
This was probably just a small oversight.  We already had the interface (I may have even added it), but the old structures were not set to implement it yet.  Both Vector and ArrayList in openJDK implement this interface to indicate that they can be efficiently used as a RandomAccess structure.

Stack also implements it (but only by extending Vector).
