### PR TITLE
fix Misc test failures

### DIFF
--- a/makefile
+++ b/makefile
@@ -1433,7 +1433,8 @@ endif
 class-name = $(patsubst $(1)/%.class,%,$(2))
 class-names = $(foreach x,$(2),$(call class-name,$(1),$(x)))
 
-test-flags = -Djava.library.path=$(build) -cp $(build)/test
+test-flags = -Djava.library.path=$(build) \
+	-cp $(build)/test$(target-path-separator)$(build)/extra-dir
 
 test-args = $(test-flags) $(input)
 

--- a/test/Misc.java
+++ b/test/Misc.java
@@ -302,14 +302,6 @@ public class Misc {
 	   (new byte[] { 0, 0, 0, 0 },
 	    java.net.InetAddress.getByName("0.0.0.0").getAddress()));
 
-    try {
-      java.net.InetAddress.getByName
-	("bs.thisdomaindoesntexistseriouslynoway");
-      throw new AssertionError();
-    } catch (java.net.UnknownHostException e) {
-      // cool
-    }
-
     expect(! staticRan);
     Static.run();
     expect(staticRan);


### PR DESCRIPTION
The Misc test was failing when run as "make input=Misc run" since
test-flags did not include $(build)/extra-dir in the class library,
leading the ClassLoader.getResources test to fail.

Also, the UnknownHostException test was not reliable -- some ISPs
(mine included) return DNS matches for bogus hostnames, defaulting to
the IP address of a webserver intended to help users with name
resolution problems.  That's dumb, I know, but I'm guessing I'm not
the only person with a dumb ISP, and it seems better to just remove
the test than make people think Avian is broken when it's really just
their DNS server that's broken.
