### PR TITLE
assume we can't use ARMv7 instructions on non-iOS platforms by default

### DIFF
--- a/makefile
+++ b/makefile
@@ -471,6 +471,12 @@ ifeq ($(arch),arm)
 	endif
 endif
 
+ifneq ($(platform),darwin)
+# By default, assume we can't use armv7-specific instructions on
+# non-iOS platforms.  Ideally, we'd detect this at runtime.
+	armv6=true
+endif
+
 ifeq ($(armv6),true)
 	cflags += -DAVIAN_ASSUME_ARMV6
 endif
@@ -1465,8 +1471,15 @@ debug: build
 vg: build
 	$(library-path) $(vg) $(test-executable) $(test-args)
 
+
 .PHONY: test
-test: build $(build)/run-tests.sh $(build)/test.sh $(unittest-executable)
+test: build-test run-test
+
+.PHONY: build-test
+build-test: build $(build)/run-tests.sh $(build)/test.sh $(unittest-executable)
+
+.PHONY: run-test
+run-test:
 ifneq ($(remote-test),true)
 	/bin/sh $(build)/run-tests.sh
 else


### PR DESCRIPTION
The only Linux/ARM machine I have access to does not support ARMv7.  I
don't know how common that is in general, but this seems like the safe
default.  You can always override it on the command line.

I've also broken the test target into build-test and run-test
subtargets, which can be useful when you're building on a shared
filesystem and running the tests on another machine (without using the
remote-test-host option).  If there's clock skew, the other machine
might try to rebuild stuff unecessarily.  Using run-test avoids
that.
