### PR TITLE
Stop using *Critical functions in throwIOException

### DIFF
--- a/classpath/java-nio.cpp
+++ b/classpath/java-nio.cpp
@@ -115,12 +115,17 @@ throwIOException(JNIEnv* e, const char* s)
   throwNew(e, "java/io/IOException", s);
 }
 
-void
-throwIOException(JNIEnv* e, jbyteArray a)
+void throwIOException(JNIEnv* e, jbyteArray a)
 {
-  jbyte* s = static_cast<jbyte*>(e->GetPrimitiveArrayCritical(a, 0));
-  throwIOException(e, reinterpret_cast<const char*>(s));
-  e->ReleasePrimitiveArrayCritical(a, s, 0);
+  size_t length = e->GetArrayLength(a);
+  uint8_t* buf = static_cast<uint8_t*>(allocate(e, length));
+  if (buf) {
+    e->GetByteArrayRegion(a, 0, length, reinterpret_cast<jbyte*>(buf));
+    throwIOException(e, reinterpret_cast<const char*>(buf));
+    free(buf);
+  } else {
+    return;
+  }
 }
 
 void

--- a/src/avian/machine.h
+++ b/src/avian/machine.h
@@ -1841,6 +1841,7 @@ allocate(Thread* t, unsigned sizeInBytes, bool objectMask)
   {
     return allocate2(t, sizeInBytes, objectMask);
   } else {
+    assert(t, t->criticalLevel == 0);
     return allocateSmall(t, sizeInBytes);
   }
 }

--- a/test/Sockets.java
+++ b/test/Sockets.java
@@ -1,0 +1,33 @@
+import java.net.SocketAddress;
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
+import java.io.IOException;
+
+public class Sockets {
+  private static void expect(boolean v) {
+    if (! v) throw new RuntimeException();
+  }
+
+  public static void testFailedBind() throws Exception {
+    final String Hostname = "localhost";
+    final int Port = 22046; // hopefully this port is unused
+    final SocketAddress Address = new InetSocketAddress(Hostname, Port);
+    final byte[] Message = "hello, world!".getBytes();
+
+    SocketChannel out = SocketChannel.open();
+    try {
+      try {
+        out.connect(Address);
+        expect(false);
+      } catch(IOException e) {
+        // We're good.  This previously triggered a vm assert, rather than an exception
+      }
+    } finally {
+      out.close();
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    testFailedBind();
+  }
+}


### PR DESCRIPTION
This was a bug, wherein upon throwing an exception, we would try to
allocate memory for the message - all while holding a critical
reference to the jbyteArray representing the exception string.  This
caused an expect to fail in allocate3.
