### PR TITLE
fix crash on exit due to order of operations bug in ~RawMonitorResource

### DIFF
--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -1009,9 +1009,9 @@ class BootContext {
 
 class Context {
  public:
-  class MyResource: public Thread::Resource {
+  class MyResource: public Thread::AutoResource {
    public:
-    MyResource(Context* c): Resource(c->thread), c(c) { }
+    MyResource(Context* c): AutoResource(c->thread), c(c) { }
 
     virtual void release() {
       c->dispose();
@@ -3857,9 +3857,9 @@ targetFieldOffset(Context* context, object field)
 
 class Stack {
  public:
-  class MyResource: public Thread::Resource {
+  class MyResource: public Thread::AutoResource {
    public:
-    MyResource(Stack* s): Resource(s->thread), s(s) { }
+    MyResource(Stack* s): AutoResource(s->thread), s(s) { }
 
     virtual void release() {
       s->zone.dispose();


### PR DESCRIPTION
The problem (which we've only been able to reproduce consistently with
the openjdk-src process=interpret build on Linux virtual machines) was
a race condition during VM shutdown.  Thread "A" would exit, see there
were other threads still running and thus enter ZombieState, which
involves acquiring and releasing a lock using RawMonitorResource.
Then the last thread (thread "B") would exit, wait for thread "A" to
release the lock, then shut down the VM, freeing all memory.  However,
thread "A" writes to its Thread object one last time after releasing
the lock (in ~Resource, the destructor of the superclass of
RawMonitorResource, which sets Thread::resource).  If thread "B" frees
that Thread before ~Resource runs, we end up writing to freed memory.

Thus, we need to update Thread::resource before releasing the lock.
Apparently C++ destructors run in order from most derived to least
derived, which is not what we want here.  My solution to split
Resource into two classes, one that has no destructor and another that
extends it (called AutoResource) which does hafe a destructor.  Now
all the classes which used to extend Resource extend AutoResource,
except for RawMonitorResource, which extends Resource directly so it
can control the order of operations.
