### PR TITLE
Change ByteArrayOutputStream's toString function to match openJDK's expectation

### DIFF
--- a/classpath/java/io/ByteArrayOutputStream.java
+++ b/classpath/java/io/ByteArrayOutputStream.java
@@ -97,6 +97,11 @@ public class ByteArrayOutputStream extends OutputStream {
     }
     return array;
   }
+  
+  @Override
+  public String toString() {
+    return new String(toByteArray());
+  }
 
   public String toString(String encoding) throws UnsupportedEncodingException {
     return new String(toByteArray(), encoding);


### PR DESCRIPTION
As documented here:
http://docs.oracle.com/javase/7/docs/api/java/io/ByteArrayOutputStream.html#toString%28%29

The normal toString() of ByteArrayOutputStream should be overridden to generate a string with the default encoding.
