### PR TITLE
fix iOS OpenJDK and simulator builds

### DIFF
--- a/makefile
+++ b/makefile
@@ -687,9 +687,6 @@ ifeq ($(platform),darwin)
 			cxx = $(ios-bin)/g++
 			cc = $(ios-bin)/gcc
 		endif
-		ar = $(ios-bin)/ar
-		ranlib = $(ios-bin)/ranlib
-		strip = $(ios-bin)/strip
 
 		flags = -isysroot $(sdk-dir)/$(target)$(ios-version).sdk \
 			$(arch-flag)
@@ -1342,7 +1339,8 @@ ifneq ($(classpath),avian)
 		$(classpath-src)/avian/VMClass.java \
 		$(classpath-src)/avian/VMField.java \
 		$(classpath-src)/avian/VMMethod.java \
-		$(classpath-src)/avian/avianvmresource/Handler.java
+		$(classpath-src)/avian/avianvmresource/Handler.java \
+		$(classpath-src)/avian/file/Handler.java
 
 	ifeq ($(openjdk),)
 		classpath-sources := $(classpath-sources) \

--- a/openjdk.pro
+++ b/openjdk.pro
@@ -237,6 +237,9 @@
 # loaded reflectively to handle embedded resources:
 -keep class avian.avianvmresource.Handler
 
+# loaded reflectively by sun.misc.Launcher:
+-keep class avian.file.Handler
+
 # refered to symbolically in MethodAccessorGenerator:
 -keep class sun.reflect.MethodAccessorImpl {
    <methods>;


### PR DESCRIPTION
With the iOS openjdk-src build, sun.misc.Launcher will throw an
InternalError if avian.file.Handler is not present, so let's make it
happy.

Also, as of recent version(s) of Xcode, there are no utilities
(e.g. ar and strip) in iPhoneSimulator.platform/usr/bin, so we can
just use the system ones.
