### PR TITLE
Add UnknownHostException to proguard config

### DIFF
--- a/vm.pro
+++ b/vm.pro
@@ -72,6 +72,7 @@
 -keep public class java.io.IOException
 -keep public class java.io.FileNotFoundException
 -keep public class java.net.SocketException
+-keep public class java.net.UnknownHostException
 -keep public class java.util.Locale
 
 # ClassLoader.getSystemClassloader() depends on the existence of this class:


### PR DESCRIPTION
In proguarded builds, we were accidentally obfuscating / eliminating UnknownHostException.
