### PR TITLE
fix log level inheritance

### DIFF
--- a/classpath/java/util/logging/Logger.java
+++ b/classpath/java/util/logging/Logger.java
@@ -32,7 +32,6 @@ public class Logger {
     if (name.equals("")) return rootLogger;
     Logger logger = new Logger(name);
     logger.parent = rootLogger;
-    logger.setLevel(Level.INFO);
     return logger;
   }
 
@@ -58,6 +57,14 @@ public class Logger {
 
   public void fine(String message) {
     log(Level.FINE, Method.getCaller(), message, null);
+  }
+
+  public void finer(String message) {
+    log(Level.FINER, Method.getCaller(), message, null);
+  }
+
+  public void finest(String message) {
+    log(Level.FINEST, Method.getCaller(), message, null);
   }
 
   public void info(String message) {
@@ -155,7 +162,7 @@ public class Logger {
   }
   
   public boolean isLoggable(Level level) {
-    return level.intValue() >= levelValue.intValue();
+    return level.intValue() >= getEffectiveLevel().intValue();
   }
   
   private static class DefaultHandler extends Handler {

--- a/test/Logging.java
+++ b/test/Logging.java
@@ -95,6 +95,10 @@ public class Logging {
   private void e() throws Exception {
     throw new Exception("Started here");
   }
+  
+  private static void expect(boolean v) {
+    if (! v) throw new RuntimeException();
+  }
 
   private static final boolean useCustomHandler = true;
   public static void main(String args[]) {
@@ -107,5 +111,37 @@ public class Logging {
 
     Logging me = new Logging();
     me.run();
+
+    { final boolean[] logged = new boolean[1];
+      Logger root = Logger.getLogger("");
+      for (Handler h : root.getHandlers()) root.removeHandler(h);
+      root.setLevel(Level.FINER);
+      root.addHandler(new Handler() {
+          public void publish(LogRecord r) {
+            logged[0] = true;
+          }
+        });
+      
+      Logger foo = Logger.getLogger("foo");
+      expect(foo.getLevel() == null);
+      expect(foo.getParent() == root);
+
+      foo.info("hi");
+      expect(logged[0]);
+
+      logged[0] = false;
+      foo.fine("hi");
+      expect(logged[0]);
+
+      logged[0] = false;
+      foo.finest("hi");
+      expect(! logged[0]);
+
+      root.setLevel(Level.FINEST);
+
+      logged[0] = false;
+      foo.finest("hi");
+      expect(logged[0]);
+    }      
   }
 }


### PR DESCRIPTION
A Logger which has not had a level set explicitly should inherit its
effective level from its parent, not just default to INFO.
