### PR TITLE
cleanly destroy MyProcessor

### DIFF
--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -8935,6 +8935,8 @@ class MyProcessor: public Processor {
     signals.unregisterHandler(SignalRegistrar::DivideByZero);
     signals.setCrashDumpDirectory(0);
 
+    this->~MyProcessor();
+
     allocator->free(this, sizeof(*this));
   }
 

--- a/src/interpret.cpp
+++ b/src/interpret.cpp
@@ -3263,8 +3263,9 @@ class MyProcessor: public Processor {
   }
 
   virtual void dispose() {
-    allocator->free(this, sizeof(*this));
     signals.setCrashDumpDirectory(0);
+    this->~MyProcessor();
+    allocator->free(this, sizeof(*this));
   }
   
   System* s;


### PR DESCRIPTION
We weren't running the SignalRegistrar destructor when shutting down the VM.
