### PR TITLE
fix non-Avian classpath build regression introduced in 7a768f2

### DIFF
--- a/test/Logging.java
+++ b/test/Logging.java
@@ -120,6 +120,9 @@ public class Logging {
           public void publish(LogRecord r) {
             logged[0] = true;
           }
+
+          public void close() { }
+          public void flush() { }
         });
       
       Logger foo = Logger.getLogger("foo");

--- a/test/ci.sh
+++ b/test/ci.sh
@@ -24,6 +24,8 @@ run make ${flags} process=interpret ${test_target}
 # bootimage and openjdk builds without openjdk-src don't work:
 if [ -z "${openjdk}" ]; then
   run make ${flags} bootimage=true ${test_target}
+  # might as well do an openjdk test while we're here:
+  run make openjdk=$JAVA_HOME ${flags} ${test_target}
 fi
 run make ${flags} tails=true continuations=true ${test_target}
 run make ${flags} codegen-targets=all


### PR DESCRIPTION
While Avian's java.util.logging.Handler only has one abstract method,
the standard version has three.
