### PR TITLE
don't use GetPrimitiveArrayCritical when throwing SocketExceptions

### DIFF
--- a/classpath/java-nio.cpp
+++ b/classpath/java-nio.cpp
@@ -143,9 +143,15 @@ throwSocketException(JNIEnv* e, const char* s)
 void
 throwSocketException(JNIEnv* e, jbyteArray a)
 {
-  jbyte* s = static_cast<jbyte*>(e->GetPrimitiveArrayCritical(a, 0));
-  throwSocketException(e, reinterpret_cast<const char*>(s));
-  e->ReleasePrimitiveArrayCritical(a, s, 0);
+  size_t length = e->GetArrayLength(a);
+  uint8_t* buf = static_cast<uint8_t*>(allocate(e, length));
+  if (buf) {
+    e->GetByteArrayRegion(a, 0, length, reinterpret_cast<jbyte*>(buf));
+    throwSocketException(e, reinterpret_cast<const char*>(buf));
+    free(buf);
+  } else {
+    return;
+  }
 }
 
 void


### PR DESCRIPTION
690ba9c fixed this for throwIOException, but we didn't notice that
throwSocketException had the same problem.
