### PR TITLE
Improved Throwable for if getCause is overridden

### DIFF
--- a/classpath/java/lang/Throwable.java
+++ b/classpath/java/lang/Throwable.java
@@ -112,9 +112,10 @@ public class Throwable implements Serializable {
       sb.append("  at ").append(trace[i].toString()).append(nl);
     }
 
-    if (getCause() != null) {
+    Throwable printCause = getCause();
+    if (printCause != null) {
       sb.append("caused by: ");
-      getCause().printStackTrace(sb, nl);
+      printCause.printStackTrace(sb, nl);
     }
   }
 


### PR DESCRIPTION
Currently if getCause() is overridden, the printStackTrace() call wont print the cause from the overriding class.  This is a small change to ensure that those causes are included in the output.
