### PR TITLE
Slowdowns if multiple threads access heap

### DIFF
--- a/test/MemoryRamp.java
+++ b/test/MemoryRamp.java
@@ -1,0 +1,66 @@
+/**
+ * Demonstrates slow multithreaded memory access.
+ */
+public class MemoryRamp implements Runnable {
+
+    private static final int ARRAY_SIZE = 10 * 1024 * 1024; //10 MB in byte
+    private static final boolean ACCESS_ARRAY = true;
+
+    @Override
+    public void run() {
+        mem();
+    }
+
+    public static void main(String[] args) {
+        // get timing for single thread
+        long singleTime = mem();
+        System.out.println("Single thread: " + singleTime + "ms");
+
+        // run the same method with different thread numbers
+        for (int threadCount : new int[] {2, 3, 4}) {
+            long time = memMulti(threadCount);
+            double timeFactor = 1.0 * singleTime * threadCount / time;
+            System.out.println(threadCount + " threads: " + time + "ms (" + timeFactor + "x)");
+        }
+    }
+
+    /**
+     * Creates and accesses a ARRAY_SIZE big byte[].
+     * @return time to create and access array in milliseconds
+     */
+    private static long mem() {
+        long start = System.currentTimeMillis();
+        final byte[] array = new byte[ARRAY_SIZE];
+        if (ACCESS_ARRAY) {
+            for (int i = 0; i < array.length; i++) {
+                //array[i] = (byte) 170; //write
+                byte x = array[i]; //read
+            }
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    /**
+     * Starts multiple threads and runs mem() in each one.
+     * @return total time for all threads
+     */
+    private static long memMulti(int numOfThreads) {
+        Thread[] threads = new Thread[numOfThreads];
+        long start = System.currentTimeMillis();
+
+        for (int i = 0; i < threads.length; i++) {
+            threads[i] = new Thread(new MemoryRamp(), "mem-");
+            threads[i].start();
+        }
+
+        try {
+            for (Thread thread : threads) {
+                thread.join();
+            }
+        }
+        catch (InterruptedException iex) {
+            throw new RuntimeException(iex);
+        }
+        return System.currentTimeMillis() - start;
+    }
+}


### PR DESCRIPTION
avian experiences big slowdowns if multiple threads access the heap in parallel.

MemoryRamp.java from the pull request demonstrates the issue: it will create a 10 MB byte array and access every byte in that array, first in a single thread and then with multiple threads in parallel.

openjdk shows the expected behaviour: the test scales with the number of cores:

```
% java MemoryRamp                              
Single thread: 16ms
2 threads: 13ms (2.4615384615384617x)
3 threads: 18ms (2.6666666666666665x)
4 threads: 17ms (3.764705882352941x)
```

avian is slower than openjdk and also degrades further in the multithreaded tests:

```
% ../build/linux-x86_64/avian-dynamic MemoryRamp 
Single thread: 361ms
2 threads: 2885ms (0.25026x)
3 threads: 2827ms (0.383092x)
4 threads: 5958ms (0.242363x)
```

it doesn't really matter performance-wise if the bytes are read or written in the loop. the array creation alone doesn't show the same slowdown.
