### PR TITLE
only enter IdleState if necessary in idleIfNecessary

### DIFF
--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -2981,7 +2981,9 @@ gcIfNecessary(MyThread* t)
 
 void idleIfNecessary(MyThread* t)
 {
-  ENTER(t, Thread::IdleState);
+  if (UNLIKELY(t->m->exclusive)) {
+    ENTER(t, Thread::IdleState);
+  }
 }
 
 unsigned

--- a/src/interpret.cpp
+++ b/src/interpret.cpp
@@ -768,7 +768,9 @@ pushField(Thread* t, object target, object field)
 }
 
 void safePoint(Thread* t) {
-  ENTER(t, Thread::IdleState);
+  if (UNLIKELY(t->m->exclusive)) {
+    ENTER(t, Thread::IdleState);
+  }
 }
 
 object


### PR DESCRIPTION
There's no need to enter IdleState (and incur synchronization
overhead) unless another thread is waiting to enter ExclusiveState.
This change improves the performance of the MemoryRamp test by a
factor of about 100.
