### PR TITLE
remove redundant PROTECT usage

### DIFF
--- a/src/avian/classpath-common.h
+++ b/src/avian/classpath-common.h
@@ -513,8 +513,6 @@ invoke(Thread* t, object method, object instance, object args)
   }
 
   if (methodParameterCount(t, method)) {
-    PROTECT(t, method);
-
     unsigned specLength = byteArrayLength(t, methodSpec(t, method));
     THREAD_RUNTIME_ARRAY(t, char, spec, specLength);
     memcpy(RUNTIME_ARRAY_BODY(spec),


### PR DESCRIPTION
This was causing crashes at GC time since we ended up visiting the
same reference twice in a single GC cycle.
