### PR TITLE
allow stress and stress-major as valid mode= settings in the makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -932,7 +932,7 @@ ifeq ($(platform),wp8)
 	ifeq ($(mode),debug-fast)
 		build-type = Debug
 	endif
-	ifeq ($(mode),stress_major)
+	ifeq ($(mode),stress-major)
 		build-type = Release
 	endif
 	ifeq ($(mode),fast)
@@ -987,7 +987,7 @@ ifeq ($(platform),wp8)
 		cflags += -DNDEBUG
 		lflags +=
 	endif
-	ifeq ($(mode),stress_major)
+	ifeq ($(mode),stress-major)
 		cflags +=
 		lflags +=
 	endif


### PR DESCRIPTION
 (note: all tests fail in both modes)
 (edit: this failure is due more to the fact that we run them under valgrind than the mode itself)
