### PR TITLE
fix all the bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Also note that we use the upstream OpenSSL repository and apply the
 Android patches to it.  This is because it is not clear how to build
 the Android fork of OpenSSL directly without checking out and building
 the entire platform.  As of this writing, the patches apply cleanly
-against OpenSSL 1.0.1e, so that's the tag we check out, but this may
+against OpenSSL 1.0.1h, so that's the tag we check out, but this may
 change in the future when the Android fork rebases against a new
 OpenSSL version.
 

--- a/classpath/avian/ClassAddendum.java
+++ b/classpath/avian/ClassAddendum.java
@@ -22,9 +22,7 @@ public class ClassAddendum extends Addendum {
    */
   public int declaredMethodCount;
 
-  // Either a byte[] or a Pair, apparently...
-  // TODO: make it monomorphic
-  public Object enclosingClass;
+  public byte[] enclosingClass;
 
-  public Object enclosingMethod;
+  public Pair enclosingMethod;
 }

--- a/classpath/avian/Pair.java
+++ b/classpath/avian/Pair.java
@@ -1,0 +1,5 @@
+package avian;
+
+abstract class Pair {
+  // VM-visible fields in types.def
+}

--- a/classpath/java/lang/Class.java
+++ b/classpath/java/lang/Class.java
@@ -392,6 +392,12 @@ public final class Class <T> implements Type, AnnotatedElement {
     }
   }
 
+  public native Class getEnclosingClass();
+
+  public native Method getEnclosingMethod();
+
+  public native Constructor getEnclosingConstructor();
+
   public T[] getEnumConstants() {
     if (Enum.class.isAssignableFrom(this)) {
       try {

--- a/classpath/java/lang/reflect/Method.java
+++ b/classpath/java/lang/reflect/Method.java
@@ -25,6 +25,10 @@ public class Method<T> extends AccessibleObject implements Member {
     this.vmMethod = vmMethod;
   }
 
+  public boolean equals(Object o) {
+    return o instanceof Method && ((Method) o).vmMethod == vmMethod;
+  }
+
   public boolean isAccessible() {
     return accessible;
   }

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS = -s
 
 name = avian
-version = 1.0.1
+version = 1.0.2
 
 build-arch := $(shell uname -m \
 	| sed 's/^i.86$$/i386/' \
@@ -1355,21 +1355,22 @@ ifneq ($(classpath),avian)
 # them to synthesize a class:
 	classpath-sources := \
 		$(classpath-src)/avian/Addendum.java \
-		$(classpath-src)/avian/Code.java \
 		$(classpath-src)/avian/AnnotationInvocationHandler.java \
 		$(classpath-src)/avian/Assembler.java \
 		$(classpath-src)/avian/Callback.java \
 		$(classpath-src)/avian/Cell.java \
 		$(classpath-src)/avian/ClassAddendum.java \
-		$(classpath-src)/avian/InnerClassReference.java \
 		$(classpath-src)/avian/Classes.java \
+		$(classpath-src)/avian/Code.java \
 		$(classpath-src)/avian/ConstantPool.java \
 		$(classpath-src)/avian/Continuations.java \
 		$(classpath-src)/avian/FieldAddendum.java \
 		$(classpath-src)/avian/Function.java \
 		$(classpath-src)/avian/IncompatibleContinuationException.java \
+		$(classpath-src)/avian/InnerClassReference.java \
 		$(classpath-src)/avian/Machine.java \
 		$(classpath-src)/avian/MethodAddendum.java \
+		$(classpath-src)/avian/Pair.java \
 		$(classpath-src)/avian/Singleton.java \
 		$(classpath-src)/avian/Stream.java \
 		$(classpath-src)/avian/SystemClassLoader.java \
@@ -1919,6 +1920,7 @@ $(bootimage-generator): $(bootimage-generator-objects) $(vm-objects)
 		armv6=$(armv6) \
 		platform=$(bootimage-platform) \
 		target-format=$(target-format) \
+		android=$(android) \
 		openjdk=$(openjdk) \
 		openjdk-src=$(openjdk-src) \
 		bootimage-generator= \

--- a/src/avian/classpath-common.h
+++ b/src/avian/classpath-common.h
@@ -760,27 +760,6 @@ object getDeclaredClasses(Thread* t, GcClass* c, bool publicOnly)
   return makeObjectArray(t, type(t, GcJclass::Type), 0);
 }
 
-GcJclass* getDeclaringClass(Thread* t, GcClass* c)
-{
-  GcClassAddendum* addendum = c->addendum();
-  if (addendum) {
-    GcArray* table = cast<GcArray>(t, addendum->innerClassTable());
-    if (table) {
-      for (unsigned i = 0; i < table->length(); ++i) {
-        GcInnerClassReference* reference
-            = cast<GcInnerClassReference>(t, table->body()[i]);
-        if (reference->outer()
-            and strcmp(reference->inner()->body().begin(),
-                       c->name()->body().begin()) == 0) {
-          return getJClass(t, resolveClass(t, c->loader(), reference->outer()));
-        }
-      }
-    }
-  }
-
-  return 0;
-}
-
 unsigned classModifiers(Thread* t, GcClass* c)
 {
   GcClassAddendum* addendum = c->addendum();

--- a/src/avian/machine.h
+++ b/src/avian/machine.h
@@ -2332,6 +2332,8 @@ inline void scanMethodSpec(Thread* t,
 
 GcClass* findLoadedClass(Thread* t, GcClassLoader* loader, GcByteArray* spec);
 
+GcJclass* getDeclaringClass(Thread* t, GcClass* c);
+
 inline bool emptyMethod(Thread* t UNUSED, GcMethod* method)
 {
   return ((method->flags() & ACC_NATIVE) == 0)

--- a/src/classpath-avian.cpp
+++ b/src/classpath-avian.cpp
@@ -730,6 +730,15 @@ extern "C" AVIAN_EXPORT int64_t JNICALL
   return count;
 }
 
+extern "C" AVIAN_EXPORT int64_t JNICALL
+    Avian_java_lang_Thread_holdsLock(Thread* t, object, uintptr_t* arguments)
+{
+  GcMonitor* m
+      = objectMonitor(t, reinterpret_cast<object>(arguments[0]), false);
+
+  return m and m->owner() == t;
+}
+
 extern "C" AVIAN_EXPORT void JNICALL
     Avian_java_lang_Thread_yield(Thread* t, object, uintptr_t*)
 {

--- a/src/codegen/compiler/event.cpp
+++ b/src/codegen/compiler/event.cpp
@@ -475,8 +475,6 @@ class CallEvent : public Event {
       int frameOffset;
 
       if (TailCalls and (flags & Compiler::TailJump)) {
-        assertT(c, arguments.count == 0);
-
         int base = frameBase(c);
         returnAddressIndex = base + c->arch->returnAddressOffset();
         if (UseFramePointer) {

--- a/src/tools/type-generator/main.cpp
+++ b/src/tools/type-generator/main.cpp
@@ -1534,16 +1534,10 @@ void writeNameInitializations(Output* out, Module& module)
 void writeMap(Output* out, Module& module, Class* cl)
 {
   std::ostringstream ss;
-  uintptr_t ownerId = 0;
   for (std::vector<Field*>::iterator it = cl->fields.begin();
        it != cl->fields.end();
        it++) {
     Field& f = **it;
-
-    if (ownerId && ownerId != f.ownerId) {
-      ss << "Type_pad, ";
-    }
-    ownerId = f.ownerId;
 
     ss << "Type_";
     ss << enumName(module, f);
@@ -1556,9 +1550,6 @@ void writeMap(Output* out, Module& module, Class* cl)
 
   if (cl->arrayField) {
     Field& f = *cl->arrayField;
-    if (ownerId && ownerId != f.ownerId) {
-      ss << "Type_pad, ";
-    }
     ss << "Type_array, ";
     ss << "Type_";
     ss << enumName(module, f);

--- a/src/types.def
+++ b/src/types.def
@@ -130,7 +130,7 @@
 (type weakHashMap
   (extends hashMap))
 
-(type pair
+(type pair avian/Pair
   (object first)
   (object second))
 

--- a/test/Reflection.java
+++ b/test/Reflection.java
@@ -255,6 +255,11 @@ public class Reflection {
 
     expect(Baz.class.getField("foo").getAnnotation(Ann.class) == null);
     expect(Baz.class.getField("foo").getAnnotations().length == 0);
+
+    expect(new Runnable() { public void run() { } }.getClass()
+           .getEnclosingMethod().equals
+           (Reflection.class.getMethod
+            ("main", new Class[] { String[].class })));
   }
 
   protected static class Baz {

--- a/test/ci.sh
+++ b/test/ci.sh
@@ -25,8 +25,10 @@ run make ${flags} process=interpret ${test_target}
 if [ -z "${openjdk}" ]; then
   run make ${flags} bootimage=true ${test_target}
   run make ${flags} mode=debug bootimage=true ${test_target}
-  # might as well do an openjdk test while we're here:
-  run make openjdk=$JAVA_HOME ${flags} ${test_target}
+  if [ -z "${android}" ]; then
+    # might as well do an openjdk test while we're here:
+    run make openjdk=$JAVA_HOME ${flags} ${test_target}
+  fi
 fi
 run make ${flags} tails=true continuations=true ${test_target}
 run make ${flags} codegen-targets=all


### PR DESCRIPTION
So there I was, planning to just fix one little bug: Thread.holdsLock
and Thread.yield were missing for the Android class library.  Easy
enough, right?  So, I added a test, got it passing, and figured I'd go
ahead and run ci.sh with all three class libraries.  Big mistake.

Here's the stuff I found:
- minor inconsistency in README.md about OpenSSL version
- untested, broken Class.getEnclosingMethod (reported by Josh)
- JNI test failed for tails=true Android build
- Runtime.nativeExit missing for Android build
- obsolete assertion in CallEvent broke tails=true Android build
- obsolete superclass field offset padding broke bootimage=true Android build
- runtime annotation parsing broke bootimage=true Android build
  (because we couldn't modify Addendum.annotationTable for classes in
  the heap image)
- ci.sh tried building with both android=... and openjdk=..., which
  the makefile rightfully balked at

Sorry this is all in a single commit; I didn't expect so many
unrelated issues, and I'm too lazy to break them apart.

Fixes #287
