### PR TITLE
fix openjdk-src build (oversight from type-generator refactor)

### DIFF
--- a/src/avian/machine.h
+++ b/src/avian/machine.h
@@ -2437,16 +2437,16 @@ object findFieldInClass(Thread* t,
                         GcByteArray* name,
                         GcByteArray* spec);
 
-inline object findFieldInClass2(Thread* t,
-                                GcClass* class_,
-                                const char* name,
-                                const char* spec)
+inline GcField* findFieldInClass2(Thread* t,
+                                  GcClass* class_,
+                                  const char* name,
+                                  const char* spec)
 {
   PROTECT(t, class_);
   GcByteArray* n = makeByteArray(t, "%s", name);
   PROTECT(t, n);
   GcByteArray* s = makeByteArray(t, "%s", spec);
-  return findFieldInClass(t, class_, n, s);
+  return cast<GcField>(t, findFieldInClass(t, class_, n, s));
 }
 
 object findMethodInClass(Thread* t,

--- a/src/avian/util.h
+++ b/src/avian/util.h
@@ -90,7 +90,7 @@ void listAppend(Thread* t, GcList* list, object value);
 
 GcVector* vectorAppend(Thread* t, GcVector* vector, object value);
 
-object growArray(Thread* t, object array);
+GcArray* growArray(Thread* t, GcArray* array);
 
 object treeQuery(Thread* t,
                  GcTreeNode* tree,


### PR DESCRIPTION
Note, on Mavericks, this still leaves me with the following problems (which have not been affected by the refactor):

``` ignore
build/macosx-x86_64-debug-openjdk-src/openjdk/UnixFileSystem_md.c:293:18: error: invalid application of 'sizeof' to an incomplete type 'struct dirent64'
    ptr = malloc(sizeof(struct dirent64) + (PATH_MAX + 1));
                 ^     ~~~~~~~~~~~~~~~~~
build/macosx-x86_64-debug-openjdk-src/openjdk/UnixFileSystem_md.c:283:12: note: forward declaration of 'struct dirent64'
    struct dirent64 *ptr;
           ^
build/macosx-x86_64-debug-openjdk-src/openjdk/UnixFileSystem_md.c:309:24: error: incomplete definition of type 'struct dirent64'
        if (!strcmp(ptr->d_name, ".") || !strcmp(ptr->d_name, ".."))
                    ~~~^
build/macosx-x86_64-debug-openjdk-src/openjdk/UnixFileSystem_md.c:283:12: note: forward declaration of 'struct dirent64'
    struct dirent64 *ptr;
           ^
```

Applying the following patch gets farther, but fails on linking:

``` diff
diff --git a/makefile b/makefile
index 1fb2258..849c5d5 100755
--- a/makefile
+++ b/makefile
@@ -2009,7 +2009,7 @@ endif
        if [ -f openjdk-patches/$(notdir $(<)).patch ]; then \
                ( cd $(build) && patch -p0 ) < openjdk-patches/$(notdir $(<)).patch; \
        fi
-       $(cc) -fPIC $(openjdk-extra-cflags) $(openjdk-cflags) \
+       $(cc) -D_ALLBSD_SOURCE -DMACOSX -fPIC $(openjdk-extra-cflags) $(openjdk-cflags) \
                $(optimization-cflags) -w -c $(build)/openjdk/$(notdir $(<)) \
                $(call output,$(@)) -Wno-return-type
```
