### PR TITLE
fix Processes test failure for openjdk-src build with recent versions of...

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -3329,6 +3329,9 @@ uint64_t jvmInitProperties(Thread* t, uintptr_t* arguments)
           ->path());
 
   local::setProperty(t, method, *properties, "file.encoding", "UTF-8");
+
+  local::setProperty(t, method, *properties, "jdk.lang.Process.launchMechanism", "fork");
+
 #ifdef ARCH_x86_32
   local::setProperty(t, method, *properties, "os.arch", "x86");
 #elif defined ARCH_x86_64


### PR DESCRIPTION
... OpenJDK 7

It looks like the UNIXProcess class has added posix_spawn support,
which is enabled by default unless overriden by the
jdk.lang.Process.launchMechanism system property.  For some reason I
haven't bothered to investigate, posix_spawn fails on MacOS, so this
patch sets the aforementioned property to "fork" to get the old,
working behavior.
