### PR TITLE
fix bootimage lzma build

### DIFF
--- a/src/tools/bootimage-generator/main.cpp
+++ b/src/tools/bootimage-generator/main.cpp
@@ -1851,10 +1851,6 @@ void writeBootImage2(Thread* t,
       abort();
     }
 
-    SymbolInfo bootimageSymbols[]
-        = {SymbolInfo(0, bootimageStart),
-           SymbolInfo(bootimageData.length, bootimageEnd)};
-
     uint8_t* bootimage;
     unsigned bootimageLength;
     if (useLZMA) {
@@ -1873,6 +1869,10 @@ void writeBootImage2(Thread* t,
       bootimage = bootimageData.data;
       bootimageLength = bootimageData.length;
     }
+
+    SymbolInfo bootimageSymbols[]
+        = {SymbolInfo(0, bootimageStart),
+           SymbolInfo(bootimageLength, bootimageEnd)};
 
     platform->writeObject(bootimageOutput,
                           Slice<SymbolInfo>(bootimageSymbols, 2),


### PR DESCRIPTION
We were using the length of the uncompressed boot image when
generating the object file, whereas we should have been using the
compressed length.
