### PR TITLE
fix crash in Posix_getaddrinfo for ProGuarded Android build

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ setting the boot classpath to "[bootJar]".
     $ cat >embedded-jar-main.cpp <<EOF
     #include "stdint.h"
     #include "jni.h"
-	#include "stdlib.h" 
+    #include "stdlib.h" 
     
     #if (defined __MINGW32__) || (defined _MSC_VER)
     #  define EXPORT __declspec(dllexport)

--- a/android.pro
+++ b/android.pro
@@ -34,7 +34,9 @@
 -keep class java.net.Socket
 -keep class java.net.SocketImpl
 -keep class java.lang.String
--keep class libcore.io.StructAddrinfo
+-keep class libcore.io.StructAddrinfo {
+   <fields>;
+ }
 -keep class libcore.io.StructFlock
 -keep class libcore.io.StructGroupReq
 -keep class libcore.io.StructLinger

--- a/makefile
+++ b/makefile
@@ -1294,8 +1294,8 @@ ifneq ($(lzma),)
 
 	lzma-encoder = $(build)/lzma/lzma
 
-	lzma-build-cflags = -D_7ZIP_ST -D__STDC_CONSTANT_MACROS -fno-rtti \
-		-fno-exceptions -I$(lzma)/C
+	lzma-build-cflags = -D_7ZIP_ST -D__STDC_CONSTANT_MACROS \
+		-fno-exceptions -fPIC -I$(lzma)/C
 
 	lzma-cflags = $(lzma-build-cflags) $(classpath-extra-cflags)
 


### PR DESCRIPTION
Posix_getaddrinfo needs to access fields in libcore.io.StructAddrinfo
via JNI, so we tell ProGuard to preserve them.

This commit also includes a minor indentation tweek in README.md and
removes -fno-rtti from lzma-build-cflags to avoid a warning from GCC.
