### PR TITLE
add hashCode and equals methods to java/util/Map

### DIFF
--- a/classpath/java/util/Map.java
+++ b/classpath/java/util/Map.java
@@ -35,6 +35,10 @@ public interface Map<K, V> {
 
   public Collection<V> values();
 
+  public boolean equals(Object other);
+
+  public int hashCode();
+
   public interface Entry<K, V> {
     public K getKey();
 


### PR DESCRIPTION
Granted, this is weird - but this is what openjdk does.  Therefore,
some code that is compiled for openjdk (say, protobufs) will treat
calls to Map.hashCode as interface calls instead of virtual calls, as
they would have previously been under avian's classpath.

Also note that this error caused avian to abort in findInterfaceMethod
rather than throw an AbstractMethodError or somesuch - but that's a
problem for another day.
