### PR TITLE
explicitly override UNUSED definition

### DIFF
--- a/classpath/jni-util.h
+++ b/classpath/jni-util.h
@@ -19,6 +19,10 @@
 
 #undef JNIEXPORT
 
+#ifdef UNUSED
+#undef UNUSED
+#endif
+
 #if (defined __MINGW32__) || (defined _MSC_VER)
 #define PLATFORM_WINDOWS
 #define PATH_SEPARATOR ';'

--- a/classpath/sockets.h
+++ b/classpath/sockets.h
@@ -16,9 +16,9 @@
 #ifndef SOCKETS_H_
 #define SOCKETS_H_
 
-#include "avian/common.h"
 #include "jni.h"
 #include "jni-util.h"
+#include "avian/common.h"
 
 #ifdef PLATFORM_WINDOWS
 #include <winsock2.h>

--- a/src/avian/common.h
+++ b/src/avian/common.h
@@ -25,6 +25,10 @@
 #include "avian/types.h"
 #include "math.h"
 
+#ifdef UNUSED
+#undef UNUSED
+#endif
+
 #ifdef _MSC_VER
 
 #include "float.h"


### PR DESCRIPTION
Recent versions of jni.h such as the one provided by Debian Jessie's
OpenJDK define UNUSED in a way that conflicts with our definition and
usage, so we need to explicitly undefine it before redefining it to
avoid compiler noise.
