### PR TITLE
add avian.Machine.tryNative

### DIFF
--- a/classpath/avian/Machine.java
+++ b/classpath/avian/Machine.java
@@ -35,4 +35,33 @@ public abstract class Machine {
     return unsafe;
   }
 
+  /**
+   * Short version: Don't use this function -- it's evil.
+   *
+   * Long version: This is kind of a poor man's, cross-platform
+   * version of Microsoft's Structured Exception Handling.  The idea
+   * is that you can call a native function with the specified
+   * argument such that any OS signals raised (e.g. SIGSEGV, SIGBUS,
+   * SIGFPE, EXC_ACCESS_VIOLATION, etc.) prior to the function
+   * returning are converted into the appropriate Java exception
+   * (e.g. NullPointerException, ArithmeticException, etc.) and thrown
+   * from this method.  This may be useful in very specific
+   * circumstances, e.g. to work around a bug in a library that would
+   * otherwise crash your app.  On the other hand, you'd be much
+   * better off just fixing the library if possible.
+   *
+   * Caveats: The specified function should return quickly without
+   * blocking, since it will block critical VM features such as
+   * garbage collection.  The implementation is equivalent to using
+   * setjmp/longjmp to achieve a non-local return from the signal
+   * handler, meaning C++ destructors and other cleanup code might not
+   * be run if a signal is raised.  It might melt your keyboard and
+   * burn your fingertips.  Caveat lector.
+   *
+   * @param function a function pointer of type int64_t (*)(int64_t)
+   * @param argument the argument to pass to the function
+   * @return the return value of the function
+   */
+  public static native long tryNative(long function, long argument);
+
 }

--- a/src/avian/machine.h
+++ b/src/avian/machine.h
@@ -1119,6 +1119,7 @@ class Thread {
   static const unsigned ActiveFlag = 1 << 5;
   static const unsigned SystemFlag = 1 << 6;
   static const unsigned JoinFlag = 1 << 7;
+  static const unsigned TryNativeFlag = 1 << 8;
 
   class Protector {
    public:

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -309,6 +309,20 @@ extern "C" AVIAN_EXPORT void JNICALL
 
 #endif  // AVIAN_HEAPDUMP
 
+extern "C" AVIAN_EXPORT int64_t JNICALL
+    Avian_avian_Machine_tryNative(Thread* t, object, uintptr_t* arguments)
+{
+  int64_t function;
+  memcpy(&function, arguments, 8);
+  int64_t argument;
+  memcpy(&argument, arguments + 2, 8);
+
+  t->flags |= Thread::TryNativeFlag;
+  THREAD_RESOURCE0(t, t->flags &= ~Thread::TryNativeFlag);
+
+  return reinterpret_cast<int64_t (*)(int64_t)>(function)(argument);
+}
+
 extern "C" AVIAN_EXPORT void JNICALL
     Avian_java_lang_Runtime_exit(Thread* t, object, uintptr_t* arguments)
 {


### PR DESCRIPTION
This function allows you to call native code such that any
SIGSEGV/SIGBUS/SIGFPE/EXC_ACCESS_VIOLATION/etc. raised by that code is
transformed into a Java exception and thrown by tryNative.  Note that
this effectively results in a longjmp out of whatever function raised
the exception, so any C++ destructors or other cleanup code will not
be run.
