### PR TITLE
implement JVM_isNaN

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -3493,9 +3493,9 @@ extern "C" AVIAN_EXPORT jboolean JNICALL
   return version <= JNI_VERSION_1_6;
 }
 
-extern "C" AVIAN_EXPORT jboolean JNICALL EXPORT(JVM_IsNaN)(jdouble)
+extern "C" AVIAN_EXPORT jboolean JNICALL EXPORT(JVM_IsNaN)(jdouble v)
 {
-  abort();
+  return isnan(v);
 }
 
 uint64_t jvmFillInStackTrace(Thread* t, uintptr_t* arguments)


### PR DESCRIPTION
This method was previously unimplemented and untested.  However, the
JMH benchmark suite requires it, so now it's time to implement it.
