### PR TITLE
fix Class.getInterfaces to return only declared interfaces

### DIFF
--- a/classpath/java/lang/Class.java
+++ b/classpath/java/lang/Class.java
@@ -377,19 +377,18 @@ public final class Class <T> implements Type, AnnotatedElement {
   }
 
   public Class[] getInterfaces() {
-    if (vmClass.interfaceTable != null) {
-      Classes.link(vmClass);
-
-      int stride = (isInterface() ? 1 : 2);
-      Class[] array = new Class[vmClass.interfaceTable.length / stride];
-      for (int i = 0; i < array.length; ++i) {
-        array[i] = SystemClassLoader.getClass
-          ((VMClass) vmClass.interfaceTable[i * stride]);
+    ClassAddendum addendum = vmClass.addendum;
+    if (addendum != null) {
+      Object[] table = addendum.interfaceTable;
+      if (table != null) {
+        Class[] array = new Class[table.length];
+        for (int i = 0; i < table.length; ++i) {
+          array[i] = SystemClassLoader.getClass((VMClass) table[i]);
+        }
+        return array;
       }
-      return array;
-    } else {
-      return new Class[0];
     }
+    return new Class[0];
   }
 
   public native Class getEnclosingClass();

--- a/test/Reflection.java
+++ b/test/Reflection.java
@@ -269,6 +269,9 @@ public class Reflection {
     } catch (NoSuchMethodException e) {
       // cool
     }
+
+    expect(C.class.getInterfaces().length == 1);
+    expect(C.class.getInterfaces()[0].equals(B.class));
   }
 
   protected static class Baz {
@@ -307,5 +310,9 @@ interface A {
 }
 
 interface B extends A { }
+
+class C implements B {
+  public void foo() { }
+}
 
 @interface Ann { }


### PR DESCRIPTION
Previously, we returned all interfaces implemented directly or
indirectly, which did not match the JDK behavior.
