### PR TITLE
Implement JVM_FindClassFromCaller OpenJDK: 8015256: Better class accessibility

### DIFF
--- a/openjdk.ld
+++ b/openjdk.ld
@@ -88,6 +88,7 @@ SUNWprivate_1.1 {
                 JVM_EnableCompiler;
                 JVM_Exit;
                 JVM_FillInStackTrace;
+                JVM_FindClassFromCaller;
                 JVM_FindClassFromClass;
                 JVM_FindClassFromClassLoader;
                 JVM_FindClassFromBootLoader;


### PR DESCRIPTION
The latest OpenJDK secuity update broke all alternative JVM support by introducing a new symbol JVM_FindClassFromCaller

java -avian -version
java: relocation error: /usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/libjava.so: symbol JVM_FindClassFromCaller, version SUNWprivate_1.1 not defined in file libjvm.so with link time reference

The OpenJDK source tree revealed the following information:
8015256: Better class accessibility
Summary: Improve protection domain check in forName()
http://hg.openjdk.java.net/jdk7u/jdk7u/hotspot/rev/61d1e75e0a58
http://hg.openjdk.java.net/jdk7u/jdk7u/jdk/rev/16cd2826a58f

JVM_FindClassFromCaller appears to work quite similar to JVM_FindClassFromClassLoader with the twist that the protection domain that belongs to the caller class argument shall be used during the lookup of the class.

This implements JVM_FindClassFromCaller for avian with this obvious TODO:
/\* XXX The caller's protection domain should be used during
    the resolveClass but there is no specification or
    unit-test in OpenJDK documenting the desired effect */

java -avian -version
java version "1.7.0_65"
OpenJDK Runtime Environment (IcedTea 2.5.3) (7u71-2.5.3-0ubuntu0.14.04.1)
Avian (build 1.2.0-SNAPSHOT, )
