### PR TITLE
fix MSYS/MinGW build

### DIFF
--- a/makefile
+++ b/makefile
@@ -240,7 +240,6 @@ ifneq ($(android),)
 		-g3 \
 		-Werror \
 		-Wno-shift-count-overflow
-	
 
 	# on Windows (in MinGW-based build) there are neither __BEGIN_DECLS nor __END_DECLS
 	# defines; we don't want to patch every file that uses them, so we stub them in
@@ -815,7 +814,7 @@ ifeq ($(platform),windows)
 	rpath =
 
 	lflags = -L$(lib) $(common-lflags) -lws2_32 -liphlpapi -mconsole
-	cflags = -I$(inc) $(common-cflags) -DWINVER=0x0500
+	cflags = -I$(inc) $(common-cflags) -DWINVER=0x0500 -U__STRICT_ANSI__
 
 	ifeq (,$(filter mingw32 cygwin,$(build-platform)))
 		openjdk-extra-cflags += -I$(src)/openjdk/caseSensitive
@@ -831,7 +830,8 @@ ifeq ($(platform),windows)
 		build-system = windows
 		static-on-windows = -static
 		common-cflags += "-I$(JAVA_HOME)/include/win32"
-		build-cflags = $(common-cflags) -I$(src) -I$(inc) -mthreads
+		build-cflags = $(common-cflags) -I$(src) -I$(inc) -mthreads \
+			-D_WIN32_WINNT=0x0500
 		openjdk-extra-cflags =
 		build-lflags = -L$(lib) $(common-lflags)
 		ifeq ($(build-platform),cygwin)

--- a/src/avian/common.h
+++ b/src/avian/common.h
@@ -135,7 +135,7 @@ typedef intptr_t __attribute__((__may_alias__)) intptr_alias_t;
 #if (defined ARCH_x86_32) || (defined ARCH_arm)
 #define LD "ld"
 #if (defined _MSC_VER) || ((defined __MINGW32__) && __GNUC__ >= 4)
-#if (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#if (__GNUC__ == 4 && __GNUC_MINOR__ <= 8)
 #define LLD "I64d"
 #else
 #define LLD "lld"


### PR DESCRIPTION
MinGW defines **STRICT_ANSI** when -std=c++0x is specified, which we
have to override in order to get e.g. strdup.  Also, we need to
specify -D_WIN32_WINNT=0x0500 to get post-Windows-2000 functions like
GetModuleHandleEx.  Finally, it seems that GCC 4.8.1 wants us to use
%I64d instead of %lld on Windows.
