### PR TITLE
fix WSA error 10093 when openning a ServerSocketChannel

### DIFF
--- a/classpath/java/nio/channels/ServerSocketChannel.java
+++ b/classpath/java/nio/channels/ServerSocketChannel.java
@@ -25,6 +25,8 @@ public class ServerSocketChannel extends SelectableChannel {
   }
 
   public static ServerSocketChannel open() throws IOException {
+    Socket.init();
+    
     return new ServerSocketChannel();
   }
 


### PR DESCRIPTION
We need to call Socket.init before trying to use the Windows Socket
library.  We were already doing this in SocketChannel.open, but not in
ServerSocketChannel.open.
