### PR TITLE
use inttypes.h macros to determine printf format symbols if possible

### DIFF
--- a/src/avian/common.h
+++ b/src/avian/common.h
@@ -15,15 +15,20 @@
 #define __STDC_CONSTANT_MACROS
 #endif
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include <new>
 
-#include "stdlib.h"
-#include "stdarg.h"
-#include "stddef.h"
-#include "string.h"
-#include "stdio.h"
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+#include <inttypes.h>
 #include "avian/types.h"
-#include "math.h"
+#include <math.h>
 
 #ifdef UNUSED
 #undef UNUSED
@@ -31,7 +36,7 @@
 
 #ifdef _MSC_VER
 
-#include "float.h"
+#include <float.h>
 #include <stdint.h>
 
 #ifdef linux
@@ -132,6 +137,12 @@ typedef intptr_t __attribute__((__may_alias__)) intptr_alias_t;
 #define PATH_SEPARATOR ':'
 #endif  // not PLATFORM_WINDOWS
 
+#ifdef PRId64
+#define LLD PRId64
+#define ULD PRIu64
+#define LD PRIdPTR
+#define LX PRIxPTR
+#else
 #if (defined ARCH_x86_32) || (defined ARCH_arm)
 #define LD "ld"
 #if (defined _MSC_VER) || ((defined __MINGW32__) && __GNUC__ >= 4)
@@ -154,7 +165,7 @@ typedef intptr_t __attribute__((__may_alias__)) intptr_alias_t;
 #define LD "ld"
 #define LX "lx"
 #if (defined _MSC_VER) || (defined __MINGW32__)
-#if (__GNUC__ == 4 && __GNUC_MINOR__ < 8)
+#if (__GNUC__ == 4 && __GNUC_MINOR__ <= 8)
 #define LLD "I64d"
 #define ULD "I64x"
 #else
@@ -172,7 +183,8 @@ typedef intptr_t __attribute__((__may_alias__)) intptr_alias_t;
 #else
 #error "Unsupported architecture"
 #endif
-
+#endif
+  
 #ifdef PLATFORM_WINDOWS
 #define SO_PREFIX ""
 #else

--- a/src/interpret.cpp
+++ b/src/interpret.cpp
@@ -114,7 +114,7 @@ inline uint32_t popInt(Thread* t)
 {
   if (DebugStack) {
     fprintf(stderr,
-            "pop int %" ULD " at %d\n",
+            "pop int %" LD " at %d\n",
             t->stack[((t->sp - 1) * 2) + 1],
             t->sp - 1);
   }
@@ -167,7 +167,7 @@ inline uint32_t peekInt(Thread* t, unsigned index)
 {
   if (DebugStack) {
     fprintf(
-        stderr, "peek int %" ULD " at %d\n", t->stack[(index * 2) + 1], index);
+        stderr, "peek int %" LD " at %d\n", t->stack[(index * 2) + 1], index);
   }
 
   assertT(t, index < stackSizeInWords(t) / 2);


### PR DESCRIPTION
This addresses a recent regression where different versions of
MinGW(-w64) had different opinions about whether to use e.g. %I64d or
%lld to print 64-bit integers on 32-bit platforms.
