### PR TITLE
fix iOS ARM64 build

### DIFF
--- a/makefile
+++ b/makefile
@@ -1655,7 +1655,8 @@ $(classpath-dep): $(classpath-sources) $(classpath-jar-dep)
 	@echo "compiling classpath classes"
 	@mkdir -p $(classpath-build)
 	classes="$(shell $(MAKE) -s --no-print-directory build=$(build) \
-		$(classpath-classes))"; if [ -n "$${classes}" ]; then \
+		$(classpath-classes) arch=$(build-arch) platform=$(build-platform))"; \
+	if [ -n "$${classes}" ]; then \
 		$(javac) -source 1.6 -target 1.6 \
 			-d $(classpath-build) -bootclasspath $(boot-classpath) \
 		$${classes}; fi

--- a/src/compile-arm64.S
+++ b/src/compile-arm64.S
@@ -58,8 +58,11 @@ GLOBAL(vmInvoke):
   mov   x5, sp
   str   x5, [x0,#TARGET_THREAD_SCRATCH]
 
-  // copy arguments into place
-  sub   sp, sp, w3, uxtw
+  // copy arguments into place, reserving enough space for them, plus
+  // alignment padding
+  sub   x5, sp, w3, uxtw
+  and   sp, x5, #-16
+
   mov   x4, #0
   b     LOCAL(vmInvoke_argumentTest)
 


### PR DESCRIPTION
With these changes (and with Xcode configuration changes to force an arm64 build), hello-ios builds and runs  successfully in 64-bit mode.  Yay.

The makefile change is to avoid triggering an error during a recursive make such that platform=macosx and arch=arm64.
