### PR TITLE
Add artifact publishing to oss.jfrog.org with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,27 @@
 language: cpp
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y libc6-dev-i386 mingw-w64 gcc-mingw-w64-x86-64 g++-mingw-w64-i686 binutils-mingw-w64-x86-64 lib32z1-dev zlib1g-dev g++-mingw-w64-x86-64
+
 env:
+  matrix:
+  # - BUILD_STEP="jdk-test"
+  # - BUILD_STEP="test"
+  # - BUILD_STEP="mode=debug test"
+  # - BUILD_STEP="process=interpret test"
+  # - BUILD_STEP="mode=debug bootimage=true test"
+  # - BUILD_STEP="bootimage=true test"
+  # - BUILD_STEP="openjdk=$JAVA_HOME test"
+  # - BUILD_STEP="tails=true continuations=true heapdump=true test"
+  # - BUILD_STEP="codegen-targets=all test"
+  - BUILD_STEP="PUBLISH"
   global:
   - TERM=dumb
-  - secure: Pe7OLUvdk3DeTAShyaYsdAXBcnjdNOrtfTPt1mCP5+JKBUw3z0n7BpTgATVRBmkn866pDqxL0N3+jBgjKUpEpqOj23bTB2AeDdIzlYkFGvTd3GQQV1lMFn16I9LOgWJhkfICTJ1rIYiNf8xSkJoeKGB7eGUM0KGsTvelFfsaGVc=
-  # BINTRAY_USER
-  - secure: CauPpj2QrbgEaePEPQx+FDeZqc46HmWXHfdAyn+DA9g6np3RMyc+N/ESrJ9efc4E772rnxory2QRyyNffzi29ceNTpIzsIRDuk5WvvC+zePEsQm8kX1afsDK5g16QEvJN24jGSW9ci9uxuknqjeKVOukcFQdxssIyDe11tYWJeI=
-  # BINTRAY_API_KEY
-  - secure: Gao6KTkCbqrdCDI2hQswh1v+SpHBeF4hR1WXmCe9gjmPyJb731K2eWigQOrhPOw7Ns3nubo1FwCb5YevYmwPMLryh0f4sKJyqLL1MLbffNl5GttNF2oO3p73cJpgBfHdzabAMwAYGYbneqUZ0Qn4K8RkzXUaoBDv465KmZhqbA0=
-script: "./test/ci.sh"
-after_success:
-- "./gradlew artifactoryPublish"
+  - secure: rh1utD4shKmYtokItuRYEF9WsfTnvZO5XqnTU4DHTS7quHHgLihtOO2/3+B+2W2hEd5Obr2or8zx+zmzWcNUyLokZ0j/FRLWSScNkLzTtm12pupLrncY+/g1NIdfbhn+OLRIzBz6zB6m6a2qWFEJ+bScUNGD/7wZVtzkujqlDEE=
+  - secure: j9DOzZMCYk/BzhKK9u4XMKpCzyGOsvP2cLTp6cXE7/tkWDAPVv6BFmeqNbiLTEqk0aGX+HYbY/2YVtpRZmDzfeWtnBFF5mL1Y1tgzx1Kf155C+P6rZgt5PiQTUdXlp2umuRifY1BbXAPc3DZ2UOPUjWKnLHVbZLQRgO1zimmMx8=
+
+matrix:
+  fast_finish: true
+
+script: ./test/ci.sh STEP ${BUILD_STEP}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,7 @@ before_install:
 
 env:
   matrix:
-  - BUILD_STEP="jdk-test"
-  - BUILD_STEP="test"
-  - BUILD_STEP="mode=debug test"
-  - BUILD_STEP="process=interpret test"
-  - BUILD_STEP="mode=debug bootimage=true test"
-  - BUILD_STEP="bootimage=true test"
-  - BUILD_STEP="openjdk=$JAVA_HOME test"
-  - BUILD_STEP="tails=true continuations=true heapdump=true test"
-  - BUILD_STEP="codegen-targets=all test"
+  - BUILD_STEP=""
   - BUILD_STEP="PUBLISH"
   global:
   - TERM=dumb
@@ -24,4 +16,4 @@ env:
 matrix:
   fast_finish: true
 
-script: ./test/ci.sh STEP ${BUILD_STEP}
+script: ./test/ci.sh ${BUILD_STEP}

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ before_install:
 
 env:
   matrix:
-  # - BUILD_STEP="jdk-test"
-  # - BUILD_STEP="test"
-  # - BUILD_STEP="mode=debug test"
-  # - BUILD_STEP="process=interpret test"
-  # - BUILD_STEP="mode=debug bootimage=true test"
-  # - BUILD_STEP="bootimage=true test"
-  # - BUILD_STEP="openjdk=$JAVA_HOME test"
-  # - BUILD_STEP="tails=true continuations=true heapdump=true test"
-  # - BUILD_STEP="codegen-targets=all test"
+  - BUILD_STEP="jdk-test"
+  - BUILD_STEP="test"
+  - BUILD_STEP="mode=debug test"
+  - BUILD_STEP="process=interpret test"
+  - BUILD_STEP="mode=debug bootimage=true test"
+  - BUILD_STEP="bootimage=true test"
+  - BUILD_STEP="openjdk=$JAVA_HOME test"
+  - BUILD_STEP="tails=true continuations=true heapdump=true test"
+  - BUILD_STEP="codegen-targets=all test"
   - BUILD_STEP="PUBLISH"
   global:
   - TERM=dumb

--- a/build.gradle
+++ b/build.gradle
@@ -243,6 +243,9 @@ publishing {
 }
 
 artifactoryPublish {
+  onlyIf {
+    System.env.'TRAVIS_BRANCH' == "master"
+  }
   dependsOn assemble
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -244,7 +244,7 @@ publishing {
 
 artifactoryPublish {
   onlyIf {
-    System.env.'TRAVIS_BRANCH' == "master"
+    System.env.'TRAVIS_BRANCH' == "master" && !System.env.'TRAVIS_PULL_REQUEST'.toBoolean()
   }
   dependsOn assemble
 }

--- a/build.gradle
+++ b/build.gradle
@@ -107,12 +107,6 @@ model {
       operatingSystem SupportedOS.valueOf(platform.toUpperCase())
       architecture "${arch}"
     }
-    if(platformArch != currentPlatformArch) {
-      create(currentPlatformArch) {
-        operatingSystem SupportedOS.CURRENT
-        architecture "${currentArch}"
-      }
-    }
   }
 
   tasks {
@@ -235,7 +229,7 @@ publishing {
         artifact("${nativeBuildDir}/avian${binSuffix}") {
           name "avian"
           type publishBinSuffix
-          extension binSuffix
+          extension publishBinSuffix
         }
 
         artifact("${nativeBuildDir}/libavian.a") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Thu Aug 28 14:47:06 MDT 2014
+#Fri Jan 02 11:31:32 MST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/test/ci.sh
+++ b/test/ci.sh
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-set -e
+set -eo pipefail
 
 root_dir=$(pwd)
+
+flags="${@}"
 
 run() {
   echo '==============================================='
@@ -23,10 +25,24 @@ run_cmake() {
   cd ..
 }
 
-flags="${@}"
+publish() {
+  local platforms="${1}"
+  local arches="${2}"
+
+  local platform
+  for platform in ${platforms}; do
+    local arch
+    for arch in ${arches}; do
+      echo "------ Publishing ${platform}-${arch} ------"
+      ./gradlew artifactoryPublish -Pplatform=${platform} -Parch=${arch}
+    done
+  done
+}
 
 has_flag() {
-  local arg=$1
+  local arg=${1}
+
+  local f
   for f in ${flags}; do
     local key=$(echo $f | awk -F '=' '{print $1}')
     if [ ${key} = ${arg} ]; then
@@ -38,19 +54,34 @@ has_flag() {
 
 make_target=test
 
-test `uname -o` = "Cygwin" || run_cmake -DCMAKE_BUILD_TYPE=Debug
+if [[ "${1}" == "STEP" ]]; then
+  shift 1
+  if [[ "${1}" == "PUBLISH" ]]; then
+    if [[ $(uname -s) == "Darwin" || ${TRAVIS_OS_NAME} == "osx" ]]; then
+      publish "macosx" "i386 x86_64"
+    elif [[ $(uname -s) == "Linux" ]]; then
+      publish "linux windows" "i386 x86_64"
+    fi
+  else
+    run make ${@}
+  fi
+else
+  if [[ $(uname -o) != "Cygwin" ]]; then
+    run_cmake -DCMAKE_BUILD_TYPE=Debug
+  fi
 
-run make jdk-test
-run make ${flags} ${make_target}
-run make ${flags} mode=debug ${make_target}
-run make ${flags} process=interpret ${make_target}
+  run make jdk-test
+  run make ${flags} ${make_target}
+  run make ${flags} mode=debug ${make_target}
+  run make ${flags} process=interpret ${make_target}
 
-(has_flag openjdk-src || ! has_flag openjdk) && \
-  run make ${flags} mode=debug bootimage=true ${make_target} && \
-  run make ${flags} bootimage=true ${make_target}
+  (has_flag openjdk-src || ! has_flag openjdk) && \
+    run make ${flags} mode=debug bootimage=true ${make_target} && \
+    run make ${flags} bootimage=true ${make_target}
 
-(! has_flag openjdk && ! has_flag android) && \
-  run make ${flags} openjdk=$JAVA_HOME ${make_target}
+  (! has_flag openjdk && ! has_flag android) && \
+    run make ${flags} openjdk=$JAVA_HOME ${make_target}
 
-run make ${flags} tails=true continuations=true heapdump=true ${make_target}
-run make ${flags} codegen-targets=all
+  run make ${flags} tails=true continuations=true heapdump=true ${make_target}
+  run make ${flags} codegen-targets=all
+fi

--- a/test/ci.sh
+++ b/test/ci.sh
@@ -54,16 +54,11 @@ has_flag() {
 
 make_target=test
 
-if [[ "${1}" == "STEP" ]]; then
-  shift 1
-  if [[ "${1}" == "PUBLISH" ]]; then
-    if [[ $(uname -s) == "Darwin" || ${TRAVIS_OS_NAME} == "osx" ]]; then
-      publish "macosx" "i386 x86_64"
-    elif [[ $(uname -s) == "Linux" ]]; then
-      publish "linux windows" "i386 x86_64"
-    fi
-  else
-    run make ${@}
+if [[ "${1}" == "PUBLISH" ]]; then
+  if [[ $(uname -s) == "Darwin" || ${TRAVIS_OS_NAME} == "osx" ]]; then
+    publish "macosx" "i386 x86_64"
+  elif [[ $(uname -s) == "Linux" ]]; then
+    publish "linux windows" "i386 x86_64"
   fi
 else
   if [[ $(uname -o) != "Cygwin" ]]; then


### PR DESCRIPTION
Right now this will just publish the master version of Avian with flavors:
- windows (i386 and x86_64)
- linux (i386 and x86_64)

but I'm looking to get TravisCI to let us in on their MacOSX build slave pool (for internal backwards compatibility, we're using the Jenkins avian job to publish the Mac flavors to oss.jfrog.org).