### PR TITLE
Add mac publishing + testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,8 @@ env:
 
 matrix:
   fast_finish: true
+  exclude:
+    - os: osx
+      env: BUILD_STEP=""
 
 script: ./test/ci.sh ${BUILD_STEP}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: cpp
+cache: apt
 
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libc6-dev-i386 mingw-w64 gcc-mingw-w64-x86-64 g++-mingw-w64-i686 binutils-mingw-w64-x86-64 lib32z1-dev zlib1g-dev g++-mingw-w64-x86-64
+os:
+  - linux
+  - osx
 
 env:
   matrix:


### PR DESCRIPTION
- Move apt calls to ci script

Currently the mac build is failing due to JAVA_HOME not being set (it is set in the Gradle script, but not in the makefile). I'd suggest that the actual build (makefile) be set up to determine this a bit better... I won't be addressing this in this pull request.