### PR TITLE
classpath-openjdk: Fix freeZipFileEntry()

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -1793,8 +1793,6 @@ void JNICALL freeZipFileEntry(Thread* t, GcMethod* method, uintptr_t* arguments)
         file->file,
         entry->entry);
   }
-
-  t->m->heap->free(entry, sizeof(ZipFile::Entry));
 }
 
 int64_t JNICALL


### PR DESCRIPTION
Those ZipFile::Entries are part of ZipFile instance itself and will fail to free(). See :1504 and :1520 in openZipFile().