### PR TITLE
classpath-openjdk: Fix freeZipFileEntry()

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -1792,9 +1792,9 @@ void JNICALL freeZipFileEntry(Thread* t, GcMethod* method, uintptr_t* arguments)
         0,
         file->file,
         entry->entry);
-  }
 
-  t->m->heap->free(entry, sizeof(ZipFile::Entry));
+    t->m->heap->free(entry, sizeof(ZipFile::Entry));
+  }
 }
 
 int64_t JNICALL


### PR DESCRIPTION
Those ZipFile::Entries are part of ZipFile instance itself and will fail to free(). See :1504 and :1520 in openZipFile().

Tested it on something that failed before original fix in #391 PR, it's all good.