### PR TITLE
fix broken interpreter build due to out-of-order class initialization

### DIFF
--- a/src/tools/type-generator/main.cpp
+++ b/src/tools/type-generator/main.cpp
@@ -1408,8 +1408,20 @@ void writeInitializations(Output* out, Module& module)
   }
 }
 
-void writeJavaInitialization(Output* out, Class* cl)
+void writeJavaInitialization(Output* out,
+                             Class* cl,
+                             std::set<Class*>& alreadyInited)
 {
+  if (alreadyInited.find(cl) != alreadyInited.end()) {
+    return;
+  }
+
+  alreadyInited.insert(cl);
+
+  if (cl->super) {
+    writeJavaInitialization(out, cl->super, alreadyInited);
+  }
+
   out->write("bootJavaClass(t, Gc::");
   out->write(capitalize(cl->name));
   out->write("Type, ");
@@ -1436,10 +1448,11 @@ void writeJavaInitialization(Output* out, Class* cl)
 
 void writeJavaInitializations(Output* out, Module& module)
 {
+  std::set<Class*> alreadyInited;
   for (const auto p : module.classes) {
     Class* cl = p.second;
     if (cl->javaName.size()) {
-      writeJavaInitialization(out, cl);
+      writeJavaInitialization(out, cl, alreadyInited);
     }
   }
 }

--- a/test/NullPointer.java
+++ b/test/NullPointer.java
@@ -17,6 +17,12 @@ public class NullPointer {
 
   public static void main(String[] args) {
     try {
+      ((Object) null).getClass();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    try {
       throw_(null);
       throw new RuntimeException();
     } catch (NullPointerException e) {


### PR DESCRIPTION
When we initialize the vtables for bootstrap Java classes such as
java.lang.NullPointerException (i.e. classes which the VM has built-in
knowledge of), we assign the superclass's vtable to any class which
has no declared virtual methods of its own.  However, that vtable will
be null if we haven't initialized the superclass yet.  Therefore, we
must order this process such that no class is initialized until after
all its superclasses.

Fixes #396 