### PR TITLE
use unconditional branch to stack overflow thunk on ARM64

### DIFF
--- a/src/codegen/target/arm/assembler.cpp
+++ b/src/codegen/target/arm/assembler.cpp
@@ -95,7 +95,7 @@ void nextFrame(ArchitectureContext* con,
 
   if ((*start >> 20) == (TargetBytesPerWord == 8 ? 0xf94 : 0xe59)) {
     // skip stack overflow check
-    start += 3;
+    start += TargetBytesPerWord == 8 ? 4 : 3;
   }
 
   if (instruction <= start) {

--- a/src/codegen/target/arm/fixup.cpp
+++ b/src/codegen/target/arm/fixup.cpp
@@ -102,21 +102,22 @@ void* updateOffset(vm::System* s, uint8_t* instruction, int64_t value)
   int32_t v;
   int32_t mask;
   if (vm::TargetBytesPerWord == 8) {
-  if ((*p >> 24) == 0x54) {
-    // conditional branch
-    v = ((reinterpret_cast<uint8_t*>(value) - instruction) >> 2) << 5;
-    mask = 0xFFFFE0;
-  } else {
-    // unconditional branch
-    v = (reinterpret_cast<uint8_t*>(value) - instruction) >> 2;
-    mask = 0x3FFFFFF;
-  }
+    if ((*p >> 24) == 0x54) {
+      // conditional branch
+      v = ((reinterpret_cast<uint8_t*>(value) - instruction) >> 2) << 5;
+      mask = 0xFFFFE0;
+      expect(s, bounded(5, 8, v));
+    } else {
+      // unconditional branch
+      v = (reinterpret_cast<uint8_t*>(value) - instruction) >> 2;
+      mask = 0x3FFFFFF;
+      expect(s, bounded(0, 6, v));
+    }
   } else {
     v = (reinterpret_cast<uint8_t*>(value) - (instruction + 8)) >> 2;
     mask = 0xFFFFFF;
+    expect(s, bounded(0, 8, v));
   }
-
-  expect(s, bounded(0, 8, v));
 
   *p = (v & mask) | ((~mask) & *p);
 


### PR DESCRIPTION
On ARM64, conditional branches to immediate offsets can span no more
than 2^19 instructions.  In the case of the stack overflow check,
which wants to do a conditional branch from every non-leaf method to a
handler, this can be a problem, especially when compiled code grows
large as with a bootimage=true build against the OpenJDK class
library.  Therefore, we use an unconditional branch to reach the
handler on this platform.