### PR TITLE
align stack size for vmNativeCall to 16 on ARM

### DIFF
--- a/src/avian/arm.h
+++ b/src/avian/arm.h
@@ -311,7 +311,7 @@ inline uint64_t dynamicCall(void* function,
     vfpIndex = VfpCount;
   }
 
-  unsigned stackSize = stackIndex * BytesPerWord + ((stackIndex & 1) << 2);
+  unsigned stackSize = pad(stackIndex * BytesPerWord, 16);
   return vmNativeCall(function,
                       stackSize,
                       RUNTIME_ARRAY_BODY(stack),


### PR DESCRIPTION
The ARM64 ABI(s) require this, and it doesn't hurt to do it on 32-bit
ARM as well.