### PR TITLE
fix crash when calling Class.getDeclaredMethods using the OpenJDK class ...

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -2452,9 +2452,18 @@ object makeJconstructor(Thread* t,
 }
 #endif  // HAVE_JexecutableHasRealParameterData
 
+void resolveBootstrap(Thread* t, Gc::Type type)
+{
+  if (vm::type(t, type)->vmFlags() & BootstrapFlag) {
+    resolveSystemClass(t, roots(t)->bootLoader(), vm::type(t, type)->name());
+  }
+}
+
 object makeJmethod(Thread* t, GcMethod* vmMethod, int index)
 {
   PROTECT(t, vmMethod);
+
+  resolveBootstrap(t, GcJmethod::Type);
 
   object name
       = intern(t,
@@ -2558,6 +2567,8 @@ object makeJconstructor(Thread* t, GcMethod* vmMethod, int index)
 {
   PROTECT(t, vmMethod);
 
+  resolveBootstrap(t, GcJconstructor::Type);
+
   unsigned parameterCount;
   unsigned returnTypeSpec;
   object parameterTypes = resolveParameterJTypes(t,
@@ -2637,6 +2648,8 @@ object makeJconstructor(Thread* t, GcMethod* vmMethod, int index)
 object makeJfield(Thread* t, GcField* vmField, int index)
 {
   PROTECT(t, vmField);
+
+  resolveBootstrap(t, GcJfield::Type);
 
   object name
       = intern(t,

--- a/test/UnsafeTest.java
+++ b/test/UnsafeTest.java
@@ -135,6 +135,9 @@ public class UnsafeTest {
   }
 
   public static void main(String[] args) {
+    System.out.println("method count is "
+                       + Unsafe.class.getDeclaredMethods().length);
+
     Unsafe u = avian.Machine.getUnsafe();
 
     unsafeCatch(u);


### PR DESCRIPTION
...library

This method ends up defering to JVM_GetClassDeclaredMethods, which
creates an array of java.lang.reflect.Method instances and then
calls getName on each one through the java.lang.reflect.Member
interface.  However, Method is a "bootstrap" class, meaning the VM has
built-in knowledge of it and includes a tentative version built-in but
must load the real version from the classpath at runtime before
invoking methods on it.  Normally this happens naturally when Method
instances are created in Java code, but here we're creating them in
the VM instead, which doesn't automatically cause the real class to be
loaded.  So we must do so explicitly.

Fixes #398 