### PR TITLE
fix ARM64 iOS JNI crashes

### DIFF
--- a/classpath/java-lang.cpp
+++ b/classpath/java-lang.cpp
@@ -853,6 +853,12 @@ extern "C" JNIEXPORT jobjectArray JNICALL
 #elif defined ARCH_arm
   e->SetObjectArrayElement(array, index++, e->NewStringUTF("os.arch=arm"));
 
+#elif defined ARCH_arm64
+  e->SetObjectArrayElement(array, index++, e->NewStringUTF("os.arch=arm64"));
+
+#else
+#error "unknown architecture"
+
 #endif
 
 #ifdef PLATFORM_WINDOWS

--- a/classpath/jni-util.h
+++ b/classpath/jni-util.h
@@ -72,6 +72,8 @@ typedef unsigned __int64 uint64_t;
 #define ARCH_x86_64
 #elif defined __arm__
 #define ARCH_arm
+#elif defined __aarch64__
+#define ARCH_arm64
 #endif
 
 #endif  // not _MSC_VER


### PR DESCRIPTION
As documented at
https://developer.apple.com/library/ios/documentation/Xcode/Conceptual/iPhoneOSABIReference/Articles/ARM64FunctionCallingConventions.html,
the ARM64 iOS ABI differs from the generic ABI in a few important
ways.  Specifically, arguments passed via the stack are aligned
according to their natural alignment instead of 8 bytes.  The VM's
dynamic call code was aligning each argument to 8 bytes, so native JNI
code couldn't find them in their expected places.

Also, we weren't setting the "os.arch" system property on ARM64, so I
fixed that too.