### PR TITLE
fix java.io.File.delete() implementation for windows

### DIFF
--- a/classpath/java-io.cpp
+++ b/classpath/java-io.cpp
@@ -383,11 +383,20 @@ extern "C" JNIEXPORT jboolean JNICALL
 }
 
 extern "C" JNIEXPORT void JNICALL
-    Java_java_io_File_delete(JNIEnv* e, jclass, jstring path)
+Java_java_io_File_delete(JNIEnv* e, jclass, jstring path)
 {
   string_t chars = getChars(e, path);
+  int r;
   if (chars) {
-    int r = REMOVE(chars);
+#ifdef PLATFORM_WINDOWS
+    if (GetFileAttributes(chars) == FILE_ATTRIBUTE_DIRECTORY) {
+      r = !RemoveDirectory(chars);
+    } else {
+      r = REMOVE(chars);
+    }
+#else
+    r = REMOVE(chars);
+#endif
     if (r != 0) {
       throwNewErrno(e, "java/io/IOException");
     }


### PR DESCRIPTION
On windows, check if  the path is a directory. If so use RemoveDirectory.