### PR TITLE
handle arbitrary class sizes in type-generator/main.cpp

### DIFF
--- a/openjdk.ld
+++ b/openjdk.ld
@@ -23,7 +23,7 @@
 # Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
 # CA 95054 USA or visit www.sun.com if you need additional information or
 # have any questions.
-#  
+#
 #
 
 # Define public interface.
@@ -159,6 +159,7 @@ SUNWprivate_1.1 {
                 JVM_GetMethodParameterAnnotations;
                 JVM_GetPrimitiveArrayElement;
                 JVM_GetProtectionDomain;
+                JVM_GetResourceLookupCacheURLs;
                 JVM_GetSockName;
                 JVM_GetSockOpt;
                 JVM_GetStackAccessControlContext;
@@ -291,4 +292,3 @@ SUNWprivate_1.1 {
                 # This is for Forte Analyzer profiling support.
                 AsyncGetCallTrace;
 };
-

--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -441,6 +441,11 @@ class MyClasspath : public Classpath {
     setObjectClass(t, c, type(t, GcJclass::Type));
     c->setName(t, name);
     c->setVmClass(t, class_);
+#ifdef HAVE_JclassClassLoader
+    if (class_->loader() != roots(t)->bootLoader()) {
+      c->setClassLoader(t, class_->loader());
+    }
+#endif
 
     return c;
   }
@@ -4562,6 +4567,12 @@ extern "C" AVIAN_EXPORT jobject JNICALL
   uintptr_t arguments[] = {reinterpret_cast<uintptr_t>(c)};
 
   return reinterpret_cast<jobject>(run(t, jvmGetProtectionDomain, arguments));
+}
+
+extern "C" AVIAN_EXPORT jobject JNICALL
+    EXPORT(JVM_GetResourceLookupCacheURLs)(Thread*, jobject)
+{
+  return 0;
 }
 
 extern "C" AVIAN_EXPORT void JNICALL

--- a/src/tools/type-generator/io.h
+++ b/src/tools/type-generator/io.h
@@ -120,11 +120,20 @@ class Output {
 
   virtual void write(const std::string& s) = 0;
 
-  void write(int i)
+  void write(int32_t i)
   {
     static const int Size = 32;
     char s[Size];
     int c UNUSED = vm::snprintf(s, Size, "%d", i);
+    assert(c > 0 and c < Size);
+    write(s);
+  }
+
+  void writeUnsigned(uint32_t i)
+  {
+    static const int Size = 32;
+    char s[Size];
+    int c UNUSED = vm::snprintf(s, Size, "%u", i);
     assert(c > 0 and c < Size);
     write(s);
   }


### PR DESCRIPTION
OpenJDK 8 includes a core class (java.lang.Thread) which so many
fields that it exceeds the class size limit in type-generator dictated
by the logic responsible for calculating each class's GC object mask,
at least on 32-bit systems.  There was no fundamental need for this
limit -- it just made the code simpler.

This commit removes the above limit at the cost of slightly more
complicated code.  The original motivation for this change was that the
platform=macosx arch=i386 openjdk=$jdk8 build was failing.  However,
there doesn't seem to be a prebuilt JDK 8 for 32-bit OS X anywhere on
the Internet, nor is there any obvious way to build one on a modern
Mac, so it's safe to say we won't be supporting this combination
anyway.  The problem also occurs on Linux and Windows, though,
so it needs to be fixed.

