### PR TITLE
use size_t instead of unsigned in a bunch of appropriate places

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ setting the boot classpath to "[bootJar]".
       extern const uint8_t SYMBOL(end)[];
 
       EXPORT const uint8_t*
-      bootJar(unsigned* size)
+      bootJar(size_t* size)
       {
         *size = SYMBOL(end) - SYMBOL(start);
         return SYMBOL(start);
@@ -682,7 +682,7 @@ containing them.  See the previous example for instructions.
       extern const uint8_t BOOTIMAGE_BIN(end)[];
 
       EXPORT const uint8_t*
-      bootimageBin(unsigned* size)
+      bootimageBin(size_t* size)
       {
         *size = BOOTIMAGE_BIN(end) - BOOTIMAGE_BIN(start);
         return BOOTIMAGE_BIN(start);
@@ -692,7 +692,7 @@ containing them.  See the previous example for instructions.
       extern const uint8_t CODEIMAGE_BIN(end)[];
 
       EXPORT const uint8_t*
-      codeimageBin(unsigned* size)
+      codeimageBin(size_t* size)
       {
         *size = CODEIMAGE_BIN(end) - CODEIMAGE_BIN(start);
         return CODEIMAGE_BIN(start);

--- a/include/avian/system/system.h
+++ b/include/avian/system/system.h
@@ -111,7 +111,7 @@ class System : public avian::util::Aborter {
   };
 
   virtual bool success(Status) = 0;
-  virtual void* tryAllocate(unsigned sizeInBytes) = 0;
+  virtual void* tryAllocate(size_t sizeInBytes) = 0;
   virtual void free(const void* p) = 0;
   virtual Status attach(Runnable*) = 0;
   virtual Status start(Runnable*) = 0;
@@ -123,7 +123,7 @@ class System : public avian::util::Aborter {
       = 0;
 
   virtual Status map(Region**, const char* name) = 0;
-  virtual FileType stat(const char* name, unsigned* length) = 0;
+  virtual FileType stat(const char* name, size_t* length) = 0;
   virtual Status open(Directory**, const char* name) = 0;
   virtual const char* libraryPrefix() = 0;
   virtual const char* librarySuffix() = 0;
@@ -138,7 +138,7 @@ class System : public avian::util::Aborter {
   virtual void dispose() = 0;
 };
 
-inline void* allocate(System* s, unsigned size)
+inline void* allocate(System* s, size_t size)
 {
   void* p = s->tryAllocate(size);
   if (p == 0)

--- a/src/avian/classpath-common.h
+++ b/src/avian/classpath-common.h
@@ -648,7 +648,7 @@ void intercept(Thread* t,
   }
 }
 
-Finder* getFinder(Thread* t, const char* name, unsigned nameLength)
+Finder* getFinder(Thread* t, const char* name, size_t nameLength)
 {
   ACQUIRE(t, t->m->referenceLock);
 
@@ -668,10 +668,10 @@ Finder* getFinder(Thread* t, const char* name, unsigned nameLength)
       reinterpret_cast<const char*>(n->body().begin()));
 
   if (p) {
-    uint8_t* (*function)(unsigned*);
+    uint8_t* (*function)(size_t*);
     memcpy(&function, &p, BytesPerWord);
 
-    unsigned size;
+    size_t size = 0;
     uint8_t* data = function(&size);
     if (data) {
       Finder* f = makeFinder(t->m->system, t->m->heap, data, size);

--- a/src/avian/finder.h
+++ b/src/avian/finder.h
@@ -126,8 +126,8 @@ inline const uint8_t* endOfEntry(const uint8_t* p)
 
 inline bool readLine(const uint8_t* base,
                      unsigned total,
-                     unsigned* start,
-                     unsigned* length)
+                     size_t* start,
+                     size_t* length)
 {
   const uint8_t* p = base + *start;
   const uint8_t* end = base + total;
@@ -147,7 +147,7 @@ class Finder {
  public:
   class IteratorImp {
    public:
-    virtual const char* next(unsigned* size) = 0;
+    virtual const char* next(size_t* size) = 0;
     virtual void dispose() = 0;
   };
 
@@ -171,7 +171,7 @@ class Finder {
       return current != 0;
     }
 
-    const char* next(unsigned* size)
+    const char* next(size_t* size)
     {
       if (hasMore()) {
         *size = currentSize;
@@ -185,13 +185,13 @@ class Finder {
 
     IteratorImp* it;
     const char* current;
-    unsigned currentSize;
+    size_t currentSize;
   };
 
   virtual IteratorImp* iterator() = 0;
   virtual System::Region* find(const char* name) = 0;
   virtual System::FileType stat(const char* name,
-                                unsigned* length,
+                                size_t* length,
                                 bool tryDirectory = false) = 0;
   virtual const char* urlPrefix(const char* name) = 0;
   virtual const char* nextUrlPrefix(const char* name, void*& finderElementPtr)
@@ -209,7 +209,7 @@ AVIAN_EXPORT Finder* makeFinder(System* s,
 Finder* makeFinder(System* s,
                    avian::util::Alloc* a,
                    const uint8_t* jarData,
-                   unsigned jarLength);
+                   size_t jarLength);
 
 }  // namespace vm
 

--- a/src/avian/lzma.h
+++ b/src/avian/lzma.h
@@ -24,14 +24,14 @@ namespace vm {
 uint8_t* decodeLZMA(System* s,
                     avian::util::Alloc* a,
                     uint8_t* in,
-                    unsigned inSize,
-                    unsigned* outSize);
+                    size_t inSize,
+                    size_t* outSize);
 
 uint8_t* encodeLZMA(System* s,
                     avian::util::Alloc* a,
                     uint8_t* in,
-                    unsigned inSize,
-                    unsigned* outSize);
+                    size_t inSize,
+                    size_t* outSize);
 
 }  // namespace vm
 

--- a/src/avian/machine.h
+++ b/src/avian/machine.h
@@ -1062,7 +1062,7 @@ class Machine {
   JNIEnvVTable jniEnvVTable;
   uintptr_t* heapPool[ThreadHeapPoolSize];
   unsigned heapPoolIndex;
-  unsigned bootimageSize;
+  size_t bootimageSize;
 };
 
 void printTrace(Thread* t, GcThrowable* exception);

--- a/src/boot-javahome.cpp
+++ b/src/boot-javahome.cpp
@@ -22,7 +22,7 @@ extern "C" {
 extern const uint8_t SYMBOL(start)[];
 extern const uint8_t SYMBOL(end)[];
 
-AVIAN_EXPORT const uint8_t* javahomeJar(unsigned* size)
+AVIAN_EXPORT const uint8_t* javahomeJar(size_t* size)
 {
   *size = SYMBOL(end) - SYMBOL(start);
   return SYMBOL(start);

--- a/src/boot.cpp
+++ b/src/boot.cpp
@@ -33,7 +33,7 @@ extern "C" {
 extern const uint8_t BOOTIMAGE_SYMBOL(start)[];
 extern const uint8_t BOOTIMAGE_SYMBOL(end)[];
 
-AVIAN_EXPORT const uint8_t* bootimageBin(unsigned* size)
+AVIAN_EXPORT const uint8_t* bootimageBin(size_t* size)
 {
   *size = BOOTIMAGE_SYMBOL(end) - BOOTIMAGE_SYMBOL(start);
   return BOOTIMAGE_SYMBOL(start);
@@ -42,7 +42,7 @@ AVIAN_EXPORT const uint8_t* bootimageBin(unsigned* size)
 extern const uint8_t CODEIMAGE_SYMBOL(start)[];
 extern const uint8_t CODEIMAGE_SYMBOL(end)[];
 
-AVIAN_EXPORT const uint8_t* codeimageBin(unsigned* size)
+AVIAN_EXPORT const uint8_t* codeimageBin(size_t* size)
 {
   *size = CODEIMAGE_SYMBOL(end) - CODEIMAGE_SYMBOL(start);
   return CODEIMAGE_SYMBOL(start);
@@ -65,7 +65,7 @@ extern "C" {
 extern const uint8_t SYMBOL(start)[];
 extern const uint8_t SYMBOL(end)[];
 
-AVIAN_EXPORT const uint8_t* classpathJar(unsigned* size)
+AVIAN_EXPORT const uint8_t* classpathJar(size_t* size)
 {
   *size = SYMBOL(end) - SYMBOL(start);
   return SYMBOL(start);

--- a/src/lzma-decode.cpp
+++ b/src/lzma-decode.cpp
@@ -29,11 +29,11 @@ namespace vm {
 uint8_t* decodeLZMA(System* s,
                     avian::util::Alloc* a,
                     uint8_t* in,
-                    unsigned inSize,
-                    unsigned* outSize)
+                    size_t inSize,
+                    size_t* outSize)
 {
-  const unsigned PropHeaderSize = 5;
-  const unsigned HeaderSize = 13;
+  const size_t PropHeaderSize = 5;
+  const size_t HeaderSize = 13;
 
   int32_t outSize32 = read4(in + PropHeaderSize);
   expect(s, outSize32 >= 0);

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -3810,10 +3810,10 @@ void Thread::init()
 
       void* imagep = m->libraries->resolve(symbolName);
       if (imagep) {
-        uint8_t* (*imageFunction)(unsigned*);
+        uint8_t* (*imageFunction)(size_t*);
         memcpy(&imageFunction, &imagep, BytesPerWord);
 
-        unsigned size;
+        size_t size = 0;
         uint8_t* imageBytes = imageFunction(&size);
         if (lzma) {
 #ifdef AVIAN_USE_LZMA
@@ -3830,7 +3830,7 @@ void Thread::init()
         if (codeFunctionName) {
           void* codep = m->libraries->resolve(codeFunctionName);
           if (codep) {
-            uint8_t* (*codeFunction)(unsigned*);
+            uint8_t* (*codeFunction)(size_t*);
             memcpy(&codeFunction, &codep, BytesPerWord);
 
             code = codeFunction(&size);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,8 +91,8 @@ const char* mainClass(const char* jar)
 
   System::Region* region = finder->find("META-INF/MANIFEST.MF");
   if (region) {
-    unsigned start = 0;
-    unsigned length;
+    size_t start = 0;
+    size_t length;
     while (readLine(region->start(), region->length(), &start, &length)) {
       const unsigned PrefixLength = 12;
       if (strncasecmp("Main-Class: ",
@@ -226,8 +226,8 @@ int main(int ac, const char** av)
 
 #define CLASSPATH_PROPERTY "-Djava.class.path="
 
-  unsigned classpathSize = strlen(classpath);
-  unsigned classpathPropertyBufferSize = sizeof(CLASSPATH_PROPERTY)
+  size_t classpathSize = strlen(classpath);
+  size_t classpathPropertyBufferSize = sizeof(CLASSPATH_PROPERTY)
                                          + classpathSize;
 
   RUNTIME_ARRAY(char, classpathPropertyBuffer, classpathPropertyBufferSize);

--- a/src/system/posix.cpp
+++ b/src/system/posix.cpp
@@ -654,7 +654,7 @@ class MySystem : public System {
     return sigaction(signals[index], &sa, oldHandlers + index) == 0;
   }
 
-  virtual void* tryAllocate(unsigned sizeInBytes)
+  virtual void* tryAllocate(size_t sizeInBytes)
   {
     return malloc(sizeInBytes);
   }
@@ -808,7 +808,7 @@ class MySystem : public System {
     return status;
   }
 
-  virtual FileType stat(const char* name, unsigned* length)
+  virtual FileType stat(const char* name, size_t* length)
   {
 #ifdef __FreeBSD__
     // Now the hack below causes the error "Dereferencing type-punned

--- a/src/system/windows.cpp
+++ b/src/system/windows.cpp
@@ -664,7 +664,7 @@ class MySystem : public System {
     assertT(this, mutex);
   }
 
-  virtual void* tryAllocate(unsigned sizeInBytes)
+  virtual void* tryAllocate(size_t sizeInBytes)
   {
     return malloc(sizeInBytes);
   }
@@ -862,7 +862,7 @@ class MySystem : public System {
     return status;
   }
 
-  virtual FileType stat(const char* name, unsigned* length)
+  virtual FileType stat(const char* name, size_t* length)
   {
     size_t nameLen = strlen(name) * 2;
     RUNTIME_ARRAY(wchar_t, wideName, nameLen + 1);

--- a/src/tools/bootimage-generator/main.cpp
+++ b/src/tools/bootimage-generator/main.cpp
@@ -348,13 +348,13 @@ GcTriple* makeCodeImage(Thread* t,
       roots(t)->bootLoader()->as<GcSystemClassLoader>(t)->finder());
 
   for (Finder::Iterator it(finder); it.hasMore();) {
-    unsigned nameSize = 0;
+    size_t nameSize = 0;
     const char* name = it.next(&nameSize);
 
     if (endsWith(".class", name, nameSize)
         and (className == 0 or strncmp(name, className, nameSize - 6) == 0)) {
       if (false) {
-        fprintf(stderr, "pass 1 %.*s\n", nameSize - 6, name);
+        fprintf(stderr, "pass 1 %.*s\n", (int)nameSize - 6, name);
       }
       GcClass* c
           = resolveSystemClass(t,
@@ -686,13 +686,13 @@ GcTriple* makeCodeImage(Thread* t,
   }
 
   for (Finder::Iterator it(finder); it.hasMore();) {
-    unsigned nameSize = 0;
+    size_t nameSize = 0;
     const char* name = it.next(&nameSize);
 
     if (endsWith(".class", name, nameSize)
         and (className == 0 or strncmp(name, className, nameSize - 6) == 0)) {
       if (false) {
-        fprintf(stderr, "pass 2 %.*s\n", nameSize - 6, name);
+        fprintf(stderr, "pass 2 %.*s\n", (int)nameSize - 6, name);
       }
       GcClass* c = 0;
       PROTECT(t, c);


### PR DESCRIPTION
This would theoretically break compatibility with apps using embedded
classpaths, on big-endian architectures - because of the size type
extension.  However, we don't currently support any big-endian
architectures, so it shouldn't be a problem.