### PR TITLE
ensure ci.sh exits with error when any test fails

### DIFF
--- a/test/ci.sh
+++ b/test/ci.sh
@@ -86,17 +86,22 @@ else
 
   make_target=test
 
-  (! has_flag arch) && run make ${flags} jdk-test
+  if ! has_flag arch; then
+    run make ${flags} jdk-test
+  fi
+
   run make ${flags} ${make_target}
   run make ${flags} mode=debug ${make_target}
   run make ${flags} process=interpret ${make_target}
 
-  (has_flag openjdk-src || ! has_flag openjdk) && \
-    run make ${flags} mode=debug bootimage=true ${make_target} && \
+  if has_flag openjdk-src || ! has_flag openjdk; then
+    run make ${flags} mode=debug bootimage=true ${make_target}
     run make ${flags} bootimage=true ${make_target}
+  fi
 
-  (! has_flag openjdk && ! has_flag android && ! has_flag arch) && \
+  if ! has_flag openjdk && ! has_flag android && ! has_flag arch; then
     run make ${flags} openjdk=$JAVA_HOME ${make_target}
+  fi
 
   run make ${flags} tails=true continuations=true heapdump=true ${make_target}
   run make ${flags} codegen-targets=all


### PR DESCRIPTION
As explained in
http://stackoverflow.com/questions/25794905/why-does-set-e-true-false-true-not-exit,
"set -e" will only cause the script to exit if the failing command is
"unhandled".  The fancy || and && shortcuts we were using to run some
of the tests caused bash to think we were handling the errors, which
isn't what we wanted.

Fixes #416