### PR TITLE
Always include heapdump code

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ certain flags described below, all of which are optional.
         mode={debug,debug-fast,fast,small} \
         lzma=<lzma source directory> \
         bootimage={true,false} \
-        heapdump={true,false} \
         tails={true,false} \
         continuations={true,false} \
         use-clang={true,false} \
@@ -130,12 +129,6 @@ class library and ahead-of-time compiled methods.  This option is
 only valid for process=compile builds.  Note that you may need to
 specify both build-arch=x86_64 and arch=x86_64 on 64-bit systems
 where "uname -m" prints "i386".
-    * _default:_ false
-
-  * `heapdump` - if true, implement avian.Machine.dumpHeap(String),
-which, when called, will generate a snapshot of the heap in a
-simple, ad-hoc format for memory profiling purposes.  See
-heapdump.cpp for details.
     * _default:_ false
 
   * `tails` - if true, optimize each tail call by replacing the caller's

--- a/makefile
+++ b/makefile
@@ -42,9 +42,6 @@ endif
 ifeq ($(bootimage),true)
 	options := $(options)-bootimage
 endif
-ifeq ($(heapdump),true)
-	options := $(options)-heapdump
-endif
 ifeq ($(tails),true)
 	options := $(options)-tails
 endif
@@ -1239,7 +1236,8 @@ vm-sources = \
 	$(src)/classpath-$(classpath).cpp \
 	$(src)/builtin.cpp \
 	$(src)/jnienv.cpp \
-	$(src)/process.cpp
+	$(src)/process.cpp \
+	$(src)/heapdump.cpp
 
 vm-asm-sources = $(src)/$(arch).$(asm-format)
 
@@ -1310,11 +1308,7 @@ heapwalk-objects = \
 
 unittest-objects = $(call cpp-objects,$(unittest-sources),$(unittest),$(build)/unittest)
 
-ifeq ($(heapdump),true)
-	vm-sources += $(src)/heapdump.cpp
-	vm-heapwalk-objects = $(heapwalk-objects)
-	cflags += -DAVIAN_HEAPDUMP
-endif
+vm-heapwalk-objects = $(heapwalk-objects)
 
 ifeq ($(tails),true)
 	cflags += -DAVIAN_TAILS

--- a/src/avian/machine.h
+++ b/src/avian/machine.h
@@ -2554,7 +2554,6 @@ inline void NO_RETURN throw_(Thread* t, GcThrowable* e)
   t->exception = e;
 
   if (objectClass(t, e) == type(t, GcOutOfMemoryError::Type)) {
-#ifdef AVIAN_HEAPDUMP
     if (not t->m->dumpedHeapOnOOM) {
       t->m->dumpedHeapOnOOM = true;
       const char* path = findProperty(t, "avian.heap.dump");
@@ -2566,7 +2565,6 @@ inline void NO_RETURN throw_(Thread* t, GcThrowable* e)
         }
       }
     }
-#endif  // AVIAN_HEAPDUMP
 
     if (AbortOnOutOfMemoryError) {
       fprintf(stderr, "OutOfMemoryError\n");

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -300,8 +300,6 @@ extern "C" AVIAN_EXPORT int64_t JNICALL
   }
 }
 
-#ifdef AVIAN_HEAPDUMP
-
 extern "C" AVIAN_EXPORT void JNICALL
     Avian_avian_Machine_dumpHeap(Thread* t, object, uintptr_t* arguments)
 {
@@ -325,8 +323,6 @@ extern "C" AVIAN_EXPORT void JNICALL
              RUNTIME_ARRAY_BODY(n));
   }
 }
-
-#endif  // AVIAN_HEAPDUMP
 
 extern "C" AVIAN_EXPORT int64_t JNICALL
     Avian_avian_Machine_tryNative(Thread* t, object, uintptr_t* arguments)

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -3338,12 +3338,11 @@ void boot(Thread* t)
         = makeMethod(t, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, bootCode);
     PROTECT(t, bootMethod);
 
-#include "type-java-initializations.cpp"
+#    include "type-java-initializations.cpp"
+#    include "type-name-initializations.cpp"
 
-//#ifdef AVIAN_HEAPDUMP
-#include "type-name-initializations.cpp"
-    //#endif
   }
+
 }
 
 class HeapClient : public Heap::Client {


### PR DESCRIPTION
This is just a proposal, and whether we actually want to move in this direction is totally up for discussion.

This is low-hanging fruit in trimming down the test matrix for avian.  The idea is to continue doing this with some of the other flags, where possible.