### PR TITLE
fixed abs() compilation for Android classpath on OSX

### DIFF
--- a/src/classpath-android.cpp
+++ b/src/classpath-android.cpp
@@ -8,6 +8,9 @@
    There is NO WARRANTY for this software.  See license.txt for
    details. */
 
+#include <cmath>
+using namespace std;
+
 struct JavaVM;
 struct _JavaVM;
 struct _JNIEnv;
@@ -1206,7 +1209,7 @@ extern "C" AVIAN_EXPORT int64_t JNICALL
 extern "C" AVIAN_EXPORT int64_t JNICALL
     Avian_java_lang_Math_abs__J(Thread*, object, uintptr_t* arguments)
 {
-  return llabs(arguments[0]);
+  return llabs(static_cast<int64_t>(arguments[0]));
 }
 
 extern "C" AVIAN_EXPORT int64_t JNICALL

--- a/src/classpath-android.cpp
+++ b/src/classpath-android.cpp
@@ -1209,7 +1209,8 @@ extern "C" AVIAN_EXPORT int64_t JNICALL
 extern "C" AVIAN_EXPORT int64_t JNICALL
     Avian_java_lang_Math_abs__J(Thread*, object, uintptr_t* arguments)
 {
-  return llabs(static_cast<int64_t>(arguments[0]));
+  int64_t v; memcpy(&v, arguments, 8);
+  return llabs(v);
 }
 
 extern "C" AVIAN_EXPORT int64_t JNICALL


### PR DESCRIPTION
Trying to build Android class path (avian-pack) on OS X. Having a problem:
```
src/classpath-android.cpp:1209:10: error: taking the absolute value of unsigned type 'uintptr_t' (aka 'unsigned long') has no effect [-Werror,-Wabsolute-value]
  return llabs(arguments[0]);
         ^
src/classpath-android.cpp:1209:10: note: remove the call to 'llabs' since unsigned values cannot be negative
  return llabs(arguments[0]);
         ^~~~~
src/classpath-android.cpp:1215:22: error: using integer absolute value function 'abs' when argument is of floating point type [-Werror,-Wabsolute-value]
  return floatToBits(abs(bitsToFloat(arguments[0])));
                     ^
src/classpath-android.cpp:1215:22: note: use function 'std::abs' instead
  return floatToBits(abs(bitsToFloat(arguments[0])));
                     ^~~
                     std::abs
src/classpath-android.cpp:1215:22: note: include the header <cmath> or explicitly provide a declaration for 'std::abs'
2 errors generated.
```
This is the solution. Although we are not linking against standard library, we are using <code>abs</code> and <code>llabs</code> from it. Additionally i've fixed a nasty type conversion bug.