### PR TITLE
fix GCC 5.1 compiler warnings/errors

### DIFF
--- a/src/bootimage-template.cpp
+++ b/src/bootimage-template.cpp
@@ -1,10 +1,7 @@
 const unsigned NAME(BootMask) = (~static_cast<unsigned>(0))
                                 / NAME(BytesPerWord);
 
-const unsigned NAME(BootShift) = 32 - avian::util::log(NAME(BytesPerWord));
-
-const unsigned NAME(BootFlatConstant) = 1 << NAME(BootShift);
-const unsigned NAME(BootHeapOffset) = 1 << (NAME(BootShift) + 1);
+const unsigned NAME(BootShift) UNUSED = 32 - avian::util::log(NAME(BytesPerWord));
 
 inline unsigned LABEL(codeMapSize)(unsigned codeSize)
 {

--- a/src/codegen/compiler/event.cpp
+++ b/src/codegen/compiler/event.cpp
@@ -1111,10 +1111,10 @@ class CombineEvent : public Event {
                 "%p %p %d : %p %p %d\n",
                 secondValue,
                 secondValue->source,
-                secondValue->source->type(c),
+                static_cast<int>(secondValue->source->type(c)),
                 secondValue->nextWord,
                 secondValue->nextWord->source,
-                secondValue->nextWord->source->type(c));
+                static_cast<int>(secondValue->nextWord->source->type(c)));
       }
     }
 


### PR DESCRIPTION
GCC is a lot more sensitive about -Werror=unused-variable, to the
point that stuff declared in header files but unused in a given
compilation unit is flagged.  This may be due to the way we're
here's the fix.

Fixes #440 