### PR TITLE
fix GC crash for bootimage builds

### DIFF
--- a/src/heap/heap.cpp
+++ b/src/heap/heap.cpp
@@ -1001,8 +1001,8 @@ void sweepFixies(Context* c)
   assertT(c, c->markedFixies == 0);
 
   if (c->mode == Heap::MajorCollection) {
-    free(c, &(c->tenuredFixies));
-    free(c, &(c->dirtyTenuredFixies));
+    free(c, &(c->tenuredFixies), true);
+    free(c, &(c->dirtyTenuredFixies), true);
 
     c->tenuredFixieFootprint = 0;
   }


### PR DESCRIPTION
In a bootimage=true build, we create allocate certain objects as
"immortal fixies", which means they will never been deallocated at
runtime and should only be visited if/when they point to objects which
might move during garbage collection.  However, there was a bug in the
following case:

 1. immortal fixie F is updated to point to a movable object M and
 thus F is added to the list of fixies to visit during the next minor
 collection (but not the next major one, since all reachable objects
 are visited during a major collection, and there's no point in
 visiting an unreachable object, whereas during a minor collection we
 have to visit F because we don't know if it's reachable or not)

 2. a major collection occurs, but F is not reachable and thus is not
 visited, whereas M is moved

 3. a minor collection occurs, and since F is still in the list, it is
 visited, but since it contains a stale pointer to M's old location,
 we crash

The solution is to ensure unreachable immortal fixies are removed from
the above list after each major collection, thus guaranteeing they
won't be visited on any subsequent collection.

Fixes #443 