### PR TITLE
Added targets for Eclipse environment descriptor.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1686,7 +1686,7 @@ $(eclipse-ee-file): $(eclipse-jdk-dir)
 
 $(eclipse-src-dir): $(eclipse-jdk-dir)
 	@echo "symlinking classpath for $(@)"
-	@ln -sf ../../classpath $(@)
+	@ln -sf ../../../../classpath $(@)
 
 $(eclipse-bin-dir)/java$(exe-suffix): $(eclipse-bin-dir) $(executable)
 	@echo "symlinking $(executable) for $(@)"


### PR DESCRIPTION
Someone on the Google Groups site asked how to set up an Eclipse
project with Avian classpath. This patch creates the descriptor
that you can you use to do that at `$(build)/eclipse/jdk/avian.ee`.
The descriptor includes the Avian version, platform, architecture,
and build options to allow for multiple versions to exist side by
side.  Users can import the descriptor into Eclipse via:

    Window >> Preferences >> Java >> Installed JREs >> Add >> Execution
    Environment Description

Once the descriptor is imported, Avian can be used just like any other
JVM installation for Eclipse projects. Personally I use this in
conjunction with Eclim to gain code completion for Avian in vim.

The new targets also create symlinks to loosely mimic OpenJDK's
filenames and folder layout:

    build/linux-x86_64-tails-continuations/eclipse/jdk/
    ├── avian.ee
    ├── bin
    │   └── java -> ../../../avian
    ├── jre
    │   └── lib
    │       └── rt.jar -> ../../../../classpath.jar
    └── src -> ../../classpath

Annoyingly, Eclipse for some reason expects this layout to exist
even though the descriptor format has required parameters for
specifying these locations. I suppose that other software may
look for this "standard" layout in a JVM installation so it may be
generally useful.

These artifacts are only built if the platform is one of `windows`,
`linux`, or `macosx`. The symlinks might not actually work at all on
Windows, I'm not sure how things like cygwin/msys handle that and I
do not have the means to test it. If they do not work a fallback
for windows might be to actually copy the files instead of symlinking.

I realize this can be done outside of the makefile but it seemed
useful to put it here to gain access to the information about the
build location, platform, architecture, and other build options.

For the record, this contribution is my original work and is released
under the same license that Avian uses, found in the license.txt
file in this repository.