### PR TITLE
Fixed method signatures on format() methods to return PrintStream as in OpenJDK

### DIFF
--- a/classpath/java/io/PrintStream.java
+++ b/classpath/java/io/PrintStream.java
@@ -78,23 +78,25 @@ public class PrintStream extends OutputStream {
     print(String.valueOf(s));
   }
 
-  public synchronized void printf(java.util.Locale locale, String format, Object... args) {
+  public synchronized PrintStream printf(java.util.Locale locale, String format, Object... args) {
     // should this be cached in an instance variable??
     final java.util.Formatter formatter = new java.util.Formatter(this);
     formatter.format(locale, format, args);
+    return this;
   }
 
-  public synchronized void printf(String format, Object... args) {
+  public synchronized PrintStream printf(String format, Object... args) {
     final java.util.Formatter formatter = new java.util.Formatter(this);
     formatter.format(format, args);
+    return this;
   }
 
-  public void format(String format, Object... args) {
-    printf(format, args);
+  public PrintStream format(String format, Object... args) {
+    return printf(format, args);
   }
 
-  public void format(java.util.Locale locale, String format, Object... args) {
-    printf(locale, format, args);
+  public PrintStream format(java.util.Locale locale, String format, Object... args) {
+    return printf(locale, format, args);
   }
 
   public synchronized void println(String s) {


### PR DESCRIPTION
When I first implemented this I failed to notice that printf on java.io.PrintStream returns a reference to the PrintStream object for chaining method calls.  This causes exceptions at runtime in Avian if you try running code compiled for OpenJDK's standard library, and/or vice versa.  This patch brings the message signatures in line so that these exceptions do not occur.