### PR TITLE
Closeable extends AutoCloseable; RandomAccessFile implements DataInput

### DIFF
--- a/classpath/java/io/Closeable.java
+++ b/classpath/java/io/Closeable.java
@@ -10,7 +10,7 @@
 
 package java.io;
 
-public interface Closeable {
+public interface Closeable extends AutoCloseable {
   void close()
     throws IOException;
 }

--- a/classpath/java/io/RandomAccessFile.java
+++ b/classpath/java/io/RandomAccessFile.java
@@ -14,7 +14,8 @@ import java.lang.IllegalArgumentException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
-public class RandomAccessFile {
+public class RandomAccessFile implements DataInput, Closeable {
+
   private long peer;
   private File file;
   private long position = 0;
@@ -77,44 +78,44 @@ public class RandomAccessFile {
   
   public int read(byte b[], int off, int len) throws IOException {
     if(b == null)
-	  throw new IllegalArgumentException();
+      throw new IllegalArgumentException();
     if (peer == 0)
-	  throw new IOException();
-	if(len == 0)
-	  return 0;
-	if (position + len > this.length)
+      throw new IOException();
+    if(len == 0)
+      return 0;
+    if (position + len > this.length)
       throw new EOFException();
-	if (off < 0 || off + len > b.length)
+    if (off < 0 || off + len > b.length)
       throw new ArrayIndexOutOfBoundsException();
     int bytesRead = readBytes(peer, position, b, off, len);
-	position += bytesRead;
-	return bytesRead;
+    position += bytesRead;
+    return bytesRead;
   }
   
   public int read(byte b[]) throws IOException {
     if(b == null)
-	  throw new IllegalArgumentException();
+      throw new IllegalArgumentException();
     if (peer == 0)
-	  throw new IOException();
-	if(b.length == 0)
-	  return 0;
-	if (position + b.length > this.length)
+      throw new IOException();
+    if(b.length == 0)
+      return 0;
+    if (position + b.length > this.length)
       throw new EOFException();
     int bytesRead = readBytes(peer, position, b, 0, b.length);
-	position += bytesRead;
-	return bytesRead;
+    position += bytesRead;
+    return bytesRead;
   }
 
   public void readFully(byte b[], int off, int len) throws IOException {
-    if(b == null)
-	  throw new IllegalArgumentException();
+    if (b == null)
+      throw new IllegalArgumentException();
     if (peer == 0)
-	  throw new IOException();
-	if(len == 0)
-	  return;
-	if (position + len > this.length)
+      throw new IOException();
+    if(len == 0)
+      return;
+    if (position + len > this.length)
       throw new EOFException();
-	if (off < 0 || off + len > b.length)
+    if (off < 0 || off + len > b.length)
       throw new ArrayIndexOutOfBoundsException();
     int n = 0;
     do {
@@ -132,6 +133,85 @@ public class RandomAccessFile {
 
   private static native int readBytes(long peer, long position, byte[] buffer,
                                   int offset, int length);
+
+  public boolean readBoolean() throws IOException {
+    return readByte() != 0;
+  }
+
+  public int read() throws IOException {
+    try {
+      return readByte() & 0xff;
+    } catch (final EOFException e) {
+      return -1;
+    }
+  }
+
+  public byte readByte() throws IOException {
+    final byte[] buffer = new byte[1];
+    readFully(buffer);
+    return buffer[0];
+  }
+
+  public short readShort() throws IOException {
+    final byte[] buffer = new byte[2];
+    readFully(buffer);
+    return (short)((buffer[0] << 8) | buffer[1]);
+  }
+
+  public int readInt() throws IOException {
+    byte[] buf = new byte[4];
+    readFully(buf);
+    return ((buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3]);
+  }
+
+  public float readFloat() throws IOException {
+    return Float.floatToIntBits(readInt());
+  }
+
+  public double readDouble() throws IOException {
+    return Double.doubleToLongBits(readLong());
+  }
+
+  public long readLong() throws IOException {
+    return ((readInt() & 0xffffffffl) << 32) | (readInt() & 0xffffffffl);
+  }
+
+  public char readChar() throws IOException {
+    return (char)readShort();
+  }
+
+  public int readUnsignedByte() throws IOException {
+    return readByte() & 0xff;
+  }
+
+  public int readUnsignedShort() throws IOException {
+    return readShort() & 0xffff;
+  }
+
+  public String readUTF() throws IOException {
+    int length = readUnsignedShort();
+    byte[] bytes = new byte[length];
+    readFully(bytes);
+    return new String(bytes, "UTF-8");
+  }
+
+  @Deprecated
+  public String readLine() throws IOException {
+    int c = read();
+    if (c < 0) {
+      return null;
+    } else if (c == '\n') {
+      return "";
+    }
+    StringBuilder builder = new StringBuilder();
+    for (;;) {
+      builder.append((char)c);
+      c = read();
+      if (c < 0 || c == '\n') {
+        return builder.toString();
+      }
+    }
+  }
 
   public void write(int b) throws IOException {
     int count = writeBytes(peer, position, new byte[] { (byte)b }, 0, 1);


### PR DESCRIPTION
In OpenJDK, Closeable extends AutoCloseable so that you can use streams with Java 7's "try with resources" syntax.  Patch make Closeable extend from AutoCloseable to enable this functionality for Avian.

Also, RandomAccessFile in OpenJDK implements the DataInput interface.  Patch adds methods to RandomAccessFile to implement the interface.  I could add tests for this part if you'd like, but I copied the code almost exactly from Avian's DataInputStream and it looked straightforward, so I didn't.  Please let me know if you'd like me to do so.