### PR TITLE
ignore leading / for files on Windows (fixes #452)

### DIFF
--- a/classpath/avian/file/Handler.java
+++ b/classpath/avian/file/Handler.java
@@ -34,7 +34,7 @@ public class Handler extends URLStreamHandler {
     }
 
     public InputStream getInputStream() throws IOException {
-      return new FileInputStream(url.getFile());
+      return new FileInputStream(new File(url.getFile()));
     }
 
     public void connect() {

--- a/classpath/java/io/File.java
+++ b/classpath/java/io/File.java
@@ -14,6 +14,9 @@ public class File implements Serializable {
   private static final String FileSeparator
     = System.getProperty("file.separator");
 
+  private static final boolean IsWindows
+    = System.getProperty("os.name").equals("Windows");
+
   public static final String separator = FileSeparator;
 
   public static final char separatorChar = FileSeparator.charAt(0);
@@ -89,6 +92,14 @@ public class File implements Serializable {
   }
 
   private static String normalize(String path) {
+    if(IsWindows
+      && path.length() > 2
+      && path.charAt(0) == '/'
+      && path.charAt(2) == ':')
+    {
+      // remove a leading slash on Windows
+      path = path.substring(1);
+    }
     return stripSeparators
       ("\\".equals(FileSeparator) ? path.replace('/', '\\') : path);
   }

--- a/test/Files.java
+++ b/test/Files.java
@@ -3,6 +3,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 
 public class Files {
+  private static final boolean IsWindows
+    = System.getProperty("os.name").equals("Windows");
+
   private static void expect(boolean v) {
     if (! v) throw new RuntimeException();
   }
@@ -79,6 +82,12 @@ public class Files {
       } finally {
         f.delete();
       }
+    }
+
+    if(IsWindows) {
+      expect(new File("/c:\\test").getPath().equals("c:\\test"));
+    } else {
+      expect(new File("/c:\\test").getPath().equals("/c:\\test"));
     }
 
     expect(new File("foo/bar").getParent().equals("foo"));


### PR DESCRIPTION
Thanks, @keinhaar!

FYI, this is slightly different than @keinhaar's original suggestion, in that we only do the '/'-stripping on windows.  '/a:/b/c' is a perfectly valid, if unusual, path on a unix system.