### PR TITLE
disable TravisCI artifact publication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ os:
 env:
   matrix:
   - BUILD_STEP=""
-  - BUILD_STEP="PUBLISH"
+# disabled until/unless jfrog.org credentials are updated and someone
+# decides they care about published artifacts:
+#  - BUILD_STEP="PUBLISH"
   global:
   - TERM=dumb
   - secure: rh1utD4shKmYtokItuRYEF9WsfTnvZO5XqnTU4DHTS7quHHgLihtOO2/3+B+2W2hEd5Obr2or8zx+zmzWcNUyLokZ0j/FRLWSScNkLzTtm12pupLrncY+/g1NIdfbhn+OLRIzBz6zB6m6a2qWFEJ+bScUNGD/7wZVtzkujqlDEE=


### PR DESCRIPTION
This stopped working recently, apparently due to obsolete jfrog.org
credentials.  Since no-one is actually using these artifacts as far as
we are aware, I'm just disabling the task so the build doesn't
continue to fail.