### PR TITLE
add bootimage-test option to makefile

### DIFF
--- a/classpath/avian/SystemClassLoader.java
+++ b/classpath/avian/SystemClassLoader.java
@@ -83,6 +83,8 @@ public class SystemClassLoader extends ClassLoader {
       if (source != null) {
         // todo: load attributes from JAR manifest
         definePackage(name, null, null, null, null, null, null, null);
+      } else {
+        definePackage(name, null, null, null, null, null, null, null);
       }
     }
 

--- a/makefile
+++ b/makefile
@@ -45,6 +45,11 @@ ifneq ($(lzma),)
 endif
 ifeq ($(bootimage),true)
 	options := $(options)-bootimage
+	ifeq ($(bootimage-test),true)
+    # this option indicates that we should AOT-compile the test
+    # classes as well as the class library
+		options := $(options)-test
+	endif
 endif
 ifeq ($(tails),true)
 	options := $(options)-tails
@@ -108,6 +113,12 @@ winrt ?= $(root)/winrt
 wp8 ?= $(root)/wp8
 
 classpath = avian
+
+bootimage-classpath = $(classpath-build)
+
+ifeq ($(bootimage-test),true)
+	bootimage-classpath = $(classpath-build):$(test-build)
+endif
 
 test-executable = $(shell pwd)/$(executable)
 boot-classpath = $(classpath-build)
@@ -1647,7 +1658,6 @@ debug: build
 vg: build
 	$(library-path) $(vg) $(test-executable) $(test-args)
 
-
 .PHONY: test
 test: build-test run-test
 
@@ -2066,9 +2076,9 @@ else
 endif
 
 $(bootimage-object) $(codeimage-object): $(bootimage-generator) \
-		$(classpath-jar-dep)
+		$(classpath-jar-dep) $(test-dep)
 	@echo "generating bootimage and codeimage binaries from $(classpath-build) using $(<)"
-	$(<) -cp $(classpath-build) -bootimage $(bootimage-object) -codeimage $(codeimage-object) \
+	$(<) -cp $(bootimage-classpath) -bootimage $(bootimage-object) -codeimage $(codeimage-object) \
 		-bootimage-symbols $(bootimage-symbols) \
 		-codeimage-symbols $(codeimage-symbols) \
 		-hostvm $(host-vm)

--- a/makefile
+++ b/makefile
@@ -97,6 +97,12 @@ ifeq ($(platform),ios)
 	endif
 endif
 
+ifeq ($(bootimage-test),true)
+	ifneq ($(bootimage),true)
+		x := $(error "bootimage-test=true only works when bootimage=true")
+	endif
+endif
+
 aot-only = false
 root := $(shell (cd .. && pwd))
 build = build/$(platform)-$(arch)$(options)
@@ -2136,7 +2142,7 @@ $(unittest-executable): $(unittest-executable-objects)
 
 $(bootimage-generator): $(bootimage-generator-objects) $(vm-objects)
 	echo building $(bootimage-generator) arch=$(build-arch) platform=$(bootimage-platform)
-	$(MAKE) process=interpret bootimage= mode=$(mode)
+	$(MAKE) process=interpret bootimage= bootimage-test= mode=$(mode)
 	$(MAKE) mode=$(mode) \
 		build=$(host-build-root) \
 		arch=$(build-arch) \

--- a/test/Misc.java
+++ b/test/Misc.java
@@ -291,9 +291,18 @@ public class Misc {
           test = true;
         }
       }
-      expect(count == 2);
-      expect(test);
-      expect(extraDir);
+      // This test is only relevant if multi-classpath-test.txt
+      // actually exists in somewhere under the classpath from which
+      // Misc.class was loaded.  Since we run this test from an
+      // AOT-compiled boot image as well as straight from the
+      // filesystem, and the boot image does not contain
+      // multi-classpath-test.txt, we'll skip the test if it's not
+      // present.
+      if (count != 0) {
+        expect(count == 2);
+        expect(test);
+        expect(extraDir);
+      }
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/test/ci.sh
+++ b/test/ci.sh
@@ -97,6 +97,7 @@ else
   if has_flag openjdk-src || ! has_flag openjdk; then
     run make ${flags} mode=debug bootimage=true ${make_target}
     run make ${flags} bootimage=true ${make_target}
+    run make ${flags} bootimage=true bootimage-test=true ${make_target}
   fi
 
   if ! has_flag openjdk && ! has_flag android && ! has_flag arch; then


### PR DESCRIPTION
This option specifies that the test classes should be AOT-compiled
along with the class library, which allows us to test that everything
works in AOT-compiled form as well as JIT-compiled form.  This is
primarily motivated by the need to test d906db6 (support for
AOT-compilation of Java 8 lambda expressions).

Note that I had to tweak Misc because it tested something that
couldn't be done in an AOT build without a lot of extra work, and
SystemClassLoader.getPackage because it was returning null when the
requested package could not be populated with JAR manifest metadata.
Technically, we probably *should* return null for packages that don't
exist at all (in the sense that no classes have been loaded from such
a package), but tracking that kind of thing seems like more trouble
than it's worth unless someone complains about it.