### PR TITLE
Change Avian src volume path to match Dockerfile

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -38,4 +38,4 @@ fi
 
 DIR=$(cd $(dirname "$0") && cd .. && pwd)
 
-docker run --rm -i -t -v "${DIR}":/var/avian ${THE_USER} "${CONTAINER}" "${@}"
+docker run --rm -i -t -v "${DIR}":/var/src/avian ${THE_USER} "${CONTAINER}" "${@}"


### PR DESCRIPTION
Dockerfile declares the Avian src volume path as /var/src/avian
Updated build.sh to use the same volume path