### PR TITLE
fix openjdk/openjdk-src builds for latest JDKs 7 and 8

### DIFF
--- a/makefile
+++ b/makefile
@@ -166,6 +166,10 @@ library-path = $(library-path-variable)=$(build)
 
 
 ifneq ($(openjdk),)
+	openjdk-version := $(shell $(openjdk)/bin/java -version 2>&1 \
+		| head -n 1 \
+		| sed 's/.*version "1.\([^.]*\).*/\1/')
+
 	openjdk-arch = $(arch)
 	ifeq ($(arch),x86_64)
 		openjdk-arch = amd64
@@ -832,12 +836,12 @@ ifeq ($(kernel),darwin)
 		cflags += $(flags)
 		asmflags += $(flags)
 		lflags += $(flags)
-		
+
 		ios-version-min=$(ios-version)
 		ifdef ios_deployment_target
 			ios-version-min=ios_deployment_target
 		endif
-		
+
 		ifeq ($(sim),true)
 			ifeq ($(arch),x86_64)
 				classpath-extra-cflags += \
@@ -875,7 +879,7 @@ ifeq ($(kernel),darwin)
 				asmflags += -arch i386 -mmacosx-version-min=${OSX_SDK_VERSION}
 				lflags += -arch i386 -mmacosx-version-min=${OSX_SDK_VERSION}
 		endif
-	
+
 		ifeq ($(arch),x86_64)
 				classpath-extra-cflags += -arch x86_64
 				cflags += -arch x86_64
@@ -904,7 +908,9 @@ ifeq ($(platform),windows)
 	exe-suffix = .exe
 	rpath =
 
-	lflags = -L$(lib) $(common-lflags) -lws2_32 -liphlpapi -mconsole
+	lflags = -L$(lib) $(common-lflags) -lws2_32 -lversion -luuid -liphlpapi \
+		-lmswsock -mconsole
+
 	cflags = -I$(inc) $(common-cflags) -DWINVER=0x0500 -U__STRICT_ANSI__
 
 	ifeq (,$(filter mingw32 cygwin,$(build-platform)))
@@ -2264,6 +2270,11 @@ ifeq ($(platform),ios)
 			-e 's/^#ifdef __APPLE__/#if 0/' \
 			< "$(openjdk-src)/solaris/native/java/lang/childproc.h" \
 			> $(build)/openjdk/childproc.h; \
+	fi
+endif
+ifneq (7,$(openjdk-version))
+	if [ -f openjdk-patches/$(notdir $(<)).8.patch ]; then \
+		( cd $(build) && patch -p0 ) < openjdk-patches/$(notdir $(<)).8.patch; \
 	fi
 endif
 	if [ -f openjdk-patches/$(notdir $(<)).patch ]; then \

--- a/makefile
+++ b/makefile
@@ -736,7 +736,9 @@ ifeq ($(kernel),darwin)
 		sdk-dir = $(platform-dir)/Developer/SDKs
 
 		mac-version := $(shell \
-				if test -d $(sdk-dir)/MacOSX10.9.sdk; then echo 10.9; \
+			  if test -d $(sdk-dir)/MacOSX10.11.sdk; then echo 10.11; \
+			elif test -d $(sdk-dir)/MacOSX10.10.sdk; then echo 10.10; \
+			elif test -d $(sdk-dir)/MacOSX10.9.sdk; then echo 10.9; \
 			elif test -d $(sdk-dir)/MacOSX10.8.sdk; then echo 10.8; \
 			elif test -d $(sdk-dir)/MacOSX10.7.sdk; then echo 10.7; \
 			elif test -d $(sdk-dir)/MacOSX10.6.sdk; then echo 10.6; \

--- a/makefile
+++ b/makefile
@@ -2278,6 +2278,9 @@ ifneq (7,$(openjdk-version))
 	if [ -f openjdk-patches/$(notdir $(<)).8.patch ]; then \
 		( cd $(build) && patch -p0 ) < openjdk-patches/$(notdir $(<)).8.patch; \
 	fi
+	if [ -f openjdk-patches/$(notdir $(<)).8.$(platform).patch ]; then \
+		( cd $(build) && patch -p0 ) < openjdk-patches/$(notdir $(<)).8.$(platform).patch; \
+	fi
 endif
 	if [ -f openjdk-patches/$(notdir $(<)).patch ]; then \
 		( cd $(build) && patch -p0 ) < openjdk-patches/$(notdir $(<)).patch; \

--- a/openjdk-patches/Inet6AddressImpl.c.8.patch
+++ b/openjdk-patches/Inet6AddressImpl.c.8.patch
@@ -1,0 +1,15 @@
+--- openjdk/Inet6AddressImpl.c
++++ openjdk/Inet6AddressImpl.c
+@@ -360,6 +360,11 @@
+
+ #ifdef AF_INET6
+
++typedef struct icmpv6_echo_reply_lh {
++  IPV6_ADDRESS_EX Address;
++  ULONG           Status;
++  unsigned int    RoundTripTime;
++} ICMPV6_ECHO_REPLY, *PICMPV6_ECHO_REPLY;
+
+ /**
+   * ping implementation.
+

--- a/openjdk-patches/Inet6AddressImpl.c.8.patch
+++ b/openjdk-patches/Inet6AddressImpl.c.8.patch
@@ -1,14 +1,16 @@
 --- openjdk/Inet6AddressImpl.c
 +++ openjdk/Inet6AddressImpl.c
-@@ -360,6 +360,11 @@
+@@ -360,6 +360,13 @@
 
  #ifdef AF_INET6
 
++#ifdef __MINGW32__
 +typedef struct icmpv6_echo_reply_lh {
 +  IPV6_ADDRESS_EX Address;
 +  ULONG           Status;
 +  unsigned int    RoundTripTime;
 +} ICMPV6_ECHO_REPLY, *PICMPV6_ECHO_REPLY;
++#endif
 
  /**
    * ping implementation.

--- a/openjdk-patches/java_props_md.c.8.windows.patch
+++ b/openjdk-patches/java_props_md.c.8.windows.patch
@@ -1,0 +1,24 @@
+--- openjdk/java_props_md.c
++++ openjdk/java_props_md.c
+@@ -212,17 +212,17 @@
+          * SHELL32 DLL is delay load DLL and we can use the trick with
+          * __try/__except block.
+          */
+-        __try {
++        /* __try { */
+             /*
+              * For Windows Vista and later (or patched MS OS) we need to use
+              * [SHGetKnownFolderPath] call to avoid MAX_PATH length limitation.
+              * Shell32.dll (version 6.0.6000 or later)
+              */
+             hr = SHGetKnownFolderPath(&FOLDERID_Profile, KF_FLAG_DONT_VERIFY, NULL, &u_path);
+-        } __except(EXCEPTION_EXECUTE_HANDLER) {
++        /* } __except(EXCEPTION_EXECUTE_HANDLER) { */
+             /* Exception: no [SHGetKnownFolderPath] entry */
+-            hr = E_FAIL;
+-        }
++        /*     hr = E_FAIL; */
++        /* } */
+ 
+         if (FAILED(hr)) {
+             WCHAR path[MAX_PATH+1];

--- a/openjdk-src.mk
+++ b/openjdk-src.mk
@@ -314,6 +314,11 @@ else
 		sun.nio.ch.InheritedChannel \
 		sun.nio.fs.UnixNativeDispatcher \
 
+	ifneq (7,$(openjdk-version))
+		openjdk-headers-classes += \
+			jdk.net.SocketFlow
+	endif
+
 	openjdk-cflags += \
 		"-I$(openjdk-src)/solaris/javavm/export" \
 		"-I$(openjdk-src)/solaris/native/common" \

--- a/openjdk-src.mk
+++ b/openjdk-src.mk
@@ -49,7 +49,6 @@ openjdk-sources = \
 	$(openjdk-src)/share/native/java/util/zip/zip_util.c \
 	$(openjdk-src)/share/native/sun/management/VMManagementImpl.c \
 	$(openjdk-src)/share/native/sun/misc/GC.c \
-	$(openjdk-src)/share/native/sun/misc/URLClassPath.c \
 	$(openjdk-src)/share/native/sun/misc/MessageUtils.c \
 	$(openjdk-src)/share/native/sun/misc/NativeSignalHandler.c \
 	$(openjdk-src)/share/native/sun/misc/Signal.c \
@@ -143,6 +142,11 @@ openjdk-headers-classes = \
 	sun.reflect.Reflection \
 	sun.security.provider.NativeSeedGenerator
 
+ifneq (7,$(openjdk-version))
+	openjdk-sources += \
+		$(openjdk-src)/share/native/sun/misc/URLClassPath.c
+endif
+
 # todo: set properties according to architecture targeted and OpenJDK
 # version used:
 openjdk-cflags = \
@@ -181,15 +185,14 @@ ifeq ($(platform),windows)
 		$(openjdk-src)/windows/native/java/io/FileDescriptor_md.c \
 		$(openjdk-src)/windows/native/java/io/FileInputStream_md.c \
 		$(openjdk-src)/windows/native/java/io/FileOutputStream_md.c \
-		$(openjdk-src)/windows/native/java/io/FileSystem_md.c \
 		$(openjdk-src)/windows/native/java/io/io_util_md.c \
 		$(openjdk-src)/windows/native/java/io/RandomAccessFile_md.c \
-		$(openjdk-src)/windows/native/java/io/Win32FileSystem_md.c \
 		$(openjdk-src)/windows/native/java/io/WinNTFileSystem_md.c \
 		$(openjdk-src)/windows/native/java/lang/java_props_md.c \
 		$(openjdk-src)/windows/native/java/lang/ProcessEnvironment_md.c \
 		$(openjdk-src)/windows/native/java/lang/ProcessImpl_md.c \
 		$(openjdk-src)/windows/native/java/net/net_util_md.c \
+		$(openjdk-src)/windows/native/java/net/ExtendedOptionsImpl.c \
 		$(openjdk-src)/windows/native/java/net/DualStackPlainSocketImpl.c \
 		$(openjdk-src)/windows/native/java/net/InetAddressImplFactory.c \
 		$(openjdk-src)/windows/native/java/net/Inet4AddressImpl.c \
@@ -218,6 +221,12 @@ ifeq ($(platform),windows)
 		$(openjdk-src)/windows/native/sun/nio/fs/WindowsNativeDispatcher.c \
 		$(openjdk-src)/windows/native/sun/security/provider/WinCAPISeedGenerator.c
 
+	ifeq (7,$(openjdk-version))
+		openjdk-sources += \
+			$(openjdk-src)/windows/native/java/io/FileSystem_md.c \
+			$(openjdk-src)/windows/native/java/io/Win32FileSystem_md.c
+	endif
+
 	openjdk-headers-classes += \
 		java.net.DualStackPlainSocketImpl \
 		java.net.SocketImpl \
@@ -236,14 +245,22 @@ ifeq ($(platform),windows)
 		"-I$(openjdk-src)/windows/native/java/util" \
 		"-I$(openjdk-src)/windows/native/sun/nio/ch" \
 		"-I$(openjdk-src)/windows/javavm/include" \
-		"-I$(root)/win32/include" \
 		-DLOCALE_SNAME=0x0000005c \
 		-DLOCALE_SISO3166CTRYNAME2=0x00000068 \
 		-DLOCALE_SISO639LANGNAME2=0x00000067 \
 		-D_JNI_IMPLEMENTATION_ \
 		-D_JAVASOFT_WIN32_TYPEDEF_MD_H_ \
+		-D_WIN32_WINNT=0x0600 \
 		-Ds6_words=_s6_words \
-		-Ds6_bytes=_s6_bytes
+		-Ds6_bytes=_s6_bytes \
+		"-D__try=if (1)" \
+		"-D__except(a)=else"
+
+		ifeq ($(arch),x86_64)
+			openjdk-cflags += "-I$(root)/win64/include"
+		else
+			openjdk-cflags += "-I$(root)/win32/include"
+		endif
 else
 	openjdk-sources += \
 		$(shell find $(openjdk-src)/solaris/native/common -name '*.c') \
@@ -261,6 +278,7 @@ else
 		$(openjdk-src)/solaris/native/java/lang/ProcessEnvironment_md.c \
 		$(openjdk-src)/solaris/native/java/lang/UNIXProcess_md.c \
 		$(openjdk-src)/solaris/native/java/net/net_util_md.c \
+		$(openjdk-src)/solaris/native/java/net/ExtendedOptionsImpl.c \
 		$(openjdk-src)/solaris/native/java/net/InetAddressImplFactory.c \
 		$(openjdk-src)/solaris/native/java/net/Inet4AddressImpl.c \
 		$(openjdk-src)/solaris/native/java/net/Inet6AddressImpl.c \

--- a/openjdk-src.mk
+++ b/openjdk-src.mk
@@ -252,9 +252,7 @@ ifeq ($(platform),windows)
 		-D_JAVASOFT_WIN32_TYPEDEF_MD_H_ \
 		-D_WIN32_WINNT=0x0600 \
 		-Ds6_words=_s6_words \
-		-Ds6_bytes=_s6_bytes \
-		"-D__try=if (1)" \
-		"-D__except(a)=else"
+		-Ds6_bytes=_s6_bytes
 
 		ifeq ($(arch),x86_64)
 			openjdk-cflags += "-I$(root)/win64/include"


### PR DESCRIPTION
The tower of patches and hacks grows higher.  Ideally, we'll just drop
support for JDK 7 soon and clean this mess up a bit, but TravisCI
still hasn't gotten the memo that it's dead, so we muddle onward.

I've tested this on Windows, but not yet Linux or OS X.  Wanted to get
a PR before I move on to that.