### PR TITLE
update to iOS 9.2 SDK and define sysroot for iOS

### DIFF
--- a/makefile
+++ b/makefile
@@ -799,7 +799,8 @@ ifeq ($(kernel),darwin)
 		sdk-dir = $(platform-dir)/Developer/SDKs
 
 		ios-version := $(shell \
-				if test -L $(sdk-dir)/$(target)9.1.sdk; then echo 9.1; \
+				if test -L $(sdk-dir)/$(target)9.2.sdk; then echo 9.2; \
+			elif test -L $(sdk-dir)/$(target)9.1.sdk; then echo 9.1; \
 			elif test -L $(sdk-dir)/$(target)9.0.sdk; then echo 9.0; \
 			elif test -d $(sdk-dir)/$(target)8.3.sdk; then echo 8.3; \
 			elif test -d $(sdk-dir)/$(target)8.2.sdk; then echo 8.2; \
@@ -816,8 +817,10 @@ ifeq ($(kernel),darwin)
 			else echo; fi)
 
 		ifeq ($(ios-version),)
-			x := $(error "couldn't find SDK")
+			x := $(error "couldn't find SDK in $(sdk-dir)")
 		endif
+
+		sysroot = $(sdk-dir)/$(target)$(ios-version).sdk
 
 		ios-bin = $(platform-dir)/Developer/usr/bin
 

--- a/makefile
+++ b/makefile
@@ -798,23 +798,10 @@ ifeq ($(kernel),darwin)
 		platform-dir = $(developer-dir)/Platforms/$(target).platform
 		sdk-dir = $(platform-dir)/Developer/SDKs
 
-		ios-version := $(shell \
-				if test -L $(sdk-dir)/$(target)9.2.sdk; then echo 9.2; \
-			elif test -L $(sdk-dir)/$(target)9.1.sdk; then echo 9.1; \
-			elif test -L $(sdk-dir)/$(target)9.0.sdk; then echo 9.0; \
-			elif test -d $(sdk-dir)/$(target)8.3.sdk; then echo 8.3; \
-			elif test -d $(sdk-dir)/$(target)8.2.sdk; then echo 8.2; \
-			elif test -d $(sdk-dir)/$(target)8.1.sdk; then echo 8.1; \
-			elif test -d $(sdk-dir)/$(target)8.0.sdk; then echo 8.0; \
-			elif test -d $(sdk-dir)/$(target)7.1.sdk; then echo 7.1; \
-			elif test -d $(sdk-dir)/$(target)7.0.sdk; then echo 7.0; \
-			elif test -d $(sdk-dir)/$(target)6.1.sdk; then echo 6.1; \
-			elif test -d $(sdk-dir)/$(target)6.0.sdk; then echo 6.0; \
-			elif test -d $(sdk-dir)/$(target)5.1.sdk; then echo 5.1; \
-			elif test -d $(sdk-dir)/$(target)5.0.sdk; then echo 5.0; \
-			elif test -d $(sdk-dir)/$(target)4.3.sdk; then echo 4.3; \
-			elif test -d $(sdk-dir)/$(target)4.2.sdk; then echo 4.2; \
-			else echo; fi)
+		ios-version := $(shell for x in 9.3 9.2 9.1 9.0 8.3 8.2 8.1 8.0; \
+			do if test -d $(sdk-dir)/$(target)$$x.sdk \
+				-o -L $(sdk-dir)/$(target)$$x.sdk; \
+			then echo $$x; break; fi; done)
 
 		ifeq ($(ios-version),)
 			x := $(error "couldn't find SDK in $(sdk-dir)")


### PR DESCRIPTION
Previously, we only seemed to define sysroot for MacOS, not iOS, yet
we reference $(sysroot) in both cases.  This ensures it is defined in
both cases as well.