### PR TITLE
MSYS update, plan B

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ to use forward slashes in the path.
     $ make
     $ build/macosx-x86_64/avian -cp build/macosx-x86_64/test Hello
 
+#### on Windows (MSYS):
+    $ git clone git@github.com:ReadyTalk/win64.git ../win64
+    $ export JAVA_HOME="C:/Program Files/Java/jdk1.7.0_45"
+    $ make
+    $ build/windows-x86_64/avian -cp build/windows-x86_64/test Hello
+
 #### on Windows (Cygwin):
     $ git clone git@github.com:ReadyTalk/win64.git ../win64
     $ export JAVA_HOME="/cygdrive/c/Program Files/Java/jdk1.7.0_45"
@@ -174,7 +180,17 @@ devices.  See [here](https://github.com/ReadyTalk/hello-ios) for an
 example of an Xcode project for iOS which uses Avian.
 
 If you are compiling for Windows, you may either cross-compile using
-MinGW or build natively on Windows under Cygwin.
+MinGW or build natively on Windows under MSYS or Cygwin.
+
+#### Installing MSYS:
+
+  __1.__ Download and install the current MinGW and MSYS packages from
+  mingw.org, selecting the C and C++ compilers when prompted.  Use the
+  post-install script to create the filesystem link to the compiler.
+
+  __2.__ Download GNU Make 3.81 from the MSYS download page
+  (make-3.81-MSYS-1.0.11-2.tar.bz2) and extract the tar file into
+  _e.g. c:/msys/1.0_.
 
 #### Installing Cygwin:
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ to use forward slashes in the path.
     $ make
     $ build/macosx-x86_64/avian -cp build/macosx-x86_64/test Hello
 
-#### on Windows (MSYS):
-    $ git clone git@github.com:ReadyTalk/win64.git ../win64
-    $ export JAVA_HOME="C:/Program Files/Java/jdk1.7.0_45"
-    $ make
-    $ build/windows-x86_64/avian -cp build/windows-x86_64/test Hello
-
 #### on Windows (Cygwin):
     $ git clone git@github.com:ReadyTalk/win64.git ../win64
     $ export JAVA_HOME="/cygdrive/c/Program Files/Java/jdk1.7.0_45"
@@ -180,17 +174,7 @@ devices.  See [here](https://github.com/ReadyTalk/hello-ios) for an
 example of an Xcode project for iOS which uses Avian.
 
 If you are compiling for Windows, you may either cross-compile using
-MinGW or build natively on Windows under MSYS or Cygwin.
-
-#### Installing MSYS:
-
-  __1.__ Download and install the current MinGW and MSYS packages from
-  mingw.org, selecting the C and C++ compilers when prompted.  Use the
-  post-install script to create the filesystem link to the compiler.
-
-  __2.__ Download GNU Make 3.81 from the MSYS download page
-  (make-3.81-MSYS-1.0.11-2.tar.bz2) and extract the tar file into
-  _e.g. c:/msys/1.0_.
+MinGW or build natively on Windows under Cygwin.
 
 #### Installing Cygwin:
 

--- a/makefile
+++ b/makefile
@@ -17,6 +17,7 @@ build-arch := $(shell uname -m \
 build-platform := \
 	$(shell uname -s | tr [:upper:] [:lower:] \
 		| sed \
+			-e 's/^mingw32.*$$/mingw32/' \
 			-e 's/^cygwin.*$$/cygwin/' \
 			-e 's/^darwin.*$$/macosx/')
 
@@ -24,7 +25,7 @@ arch = $(build-arch)
 target-arch = $(arch)
 
 bootimage-platform = \
-	$(subst cygwin,windows,$(build-platform))
+	$(subst cygwin,windows,$(subst mingw32,windows,$(build-platform)))
 
 platform = $(bootimage-platform)
 
@@ -148,7 +149,7 @@ windows-path = echo
 
 path-separator = :
 
-ifneq (,$(filter cygwin,$(build-platform)))
+ifneq (,$(filter mingw32 cygwin,$(build-platform)))
 	path-separator = ;
 endif
 
@@ -415,6 +416,14 @@ endif
 
 input = List
 
+ifeq ($(use-clang),true)
+	build-cxx = clang++ -std=c++11
+	build-cc = clang
+else
+	build-cxx = g++
+	build-cc = gcc
+endif
+
 mflag =
 ifneq ($(kernel),darwin)
 	ifeq ($(arch),i386)
@@ -425,18 +434,10 @@ ifneq ($(kernel),darwin)
 	endif
 endif
 
-ifeq ($(use-clang),true)
-	build-cxx = clang++ -std=c++11
-	build-cc = clang
-else
-	build-cxx = g++ $(mflag)
-	build-cc = gcc $(mflag)
-endif
-
 target-format = elf
 
-cxx = $(build-cxx)
-cc = $(build-cc)
+cxx = $(build-cxx) $(mflag)
+cc = $(build-cc) $(mflag)
 
 ar = ar
 ranlib = ranlib
@@ -682,15 +683,15 @@ ifeq ($(platform),android)
 
 	build-cflags = $(common-cflags) -I$(src)
 	build-lflags = -lz -lpthread
-	ifeq ($(subst cygwin,windows,$(build-platform)),windows)
-		toolchain-host-platform = $(subst cygwin,windows,$(build-platform))
+	ifeq ($(subst cygwin,windows,$(subst mingw32,windows,$(build-platform))),windows)
+		toolchain-host-platform = $(subst cygwin,windows,$(subst mingw32,windows,$(build-platform)))
 		build-system = windows
 		build-cxx = i686-w64-mingw32-g++
 		build-cc = i686-w64-mingw32-gcc
 		sysroot = "$$(cygpath -w "$(ndk)/platforms/android-$(android-version)/arch-arm")"
 		build-cflags += "-I$(JAVA_HOME)/include/win32"
 	else
-		toolchain-host-platform = $(subst cygwin,windows,$(build-platform))-*
+		toolchain-host-platform = $(subst cygwin,windows,$(subst mingw32,windows,$(build-platform)))-*
 		sysroot = $(ndk)/platforms/android-$(android-version)/arch-arm
 		build-cflags += "-I$(JAVA_HOME)/include/linux"
 		build-lflags += -ldl
@@ -918,7 +919,7 @@ ifeq ($(platform),windows)
 
 	cflags = -I$(inc) $(common-cflags) -DWINVER=0x0500 -U__STRICT_ANSI__
 
-	ifeq (,$(filter cygwin,$(build-platform)))
+	ifeq (,$(filter mingw32 cygwin,$(build-platform)))
 		openjdk-extra-cflags += -I$(src)/openjdk/caseSensitive
 		prefix := $(shell i686-w64-mingw32-gcc --version >/dev/null 2>&1 \
 			&& echo i686-w64-mingw32- || echo x86_64-w64-mingw32-)


### PR DESCRIPTION
This reverts my earlier PR, since the avian-pack project still needs MSYS support.  However, I still want to remove the README instructions to ensure new users pick Cygwin instead, since that's better supported on our side.