### PR TITLE
Added support for MSYS2 with mingw-w64 toolchain

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ MAKEFLAGS = -s
 name = avian
 version := $(shell grep version gradle.properties | cut -d'=' -f2)
 
-java-version := $(shell $(JAVA_HOME)/bin/java -version 2>&1 \
+java-version := $(shell "$(JAVA_HOME)/bin/java" -version 2>&1 \
 	| head -n 1 \
 	| sed 's/.*version "1.\([^.]*\).*/\1/')
 
@@ -17,6 +17,7 @@ build-arch := $(shell uname -m \
 build-platform := \
 	$(shell uname -s | tr [:upper:] [:lower:] \
 		| sed \
+			-e 's/^mingw64.*$$/mingw32/' \
 			-e 's/^mingw32.*$$/mingw32/' \
 			-e 's/^cygwin.*$$/cygwin/' \
 			-e 's/^darwin.*$$/macosx/')


### PR DESCRIPTION
I've made some minor changes to support MSYS2 (old MSYS should work as well).

In order to config the environment you should only install MSYS2, run and then use pacman (yeah, it does contain package manager inside, cool!) to install mingw64 toolchain like this:

    pacman -S mingw-w64-x86_64-gcc

Then you close the main shell, open "mingw64_shell.bat" (this is a special msys2 shell for mingw64 environment) and

    cd avian && make

Don't forget to set JAVA_HOME ;)

Please, test it on your site and tell me if you have any troubles. Should I update the building instruction as well?