### PR TITLE
Don't access length field of non-array objects (fixes #486)

### DIFF
--- a/src/avian/machine.h
+++ b/src/avian/machine.h
@@ -1987,11 +1987,14 @@ inline unsigned baseSize(Thread* t UNUSED, object o, GcClass* class_)
 {
   assertT(t, class_->fixedSize() >= BytesPerWord);
 
-  return ceilingDivide(class_->fixedSize(), BytesPerWord)
-         + ceilingDivide(class_->arrayElementSize()
-                         * fieldAtOffset<uintptr_t>(
-                               o, class_->fixedSize() - BytesPerWord),
-                         BytesPerWord);
+  unsigned size = ceilingDivide(class_->fixedSize(), BytesPerWord);
+  if (class_->arrayElementSize() > 0) {
+    size += ceilingDivide(class_->arrayElementSize()
+                       * fieldAtOffset<uintptr_t>(
+                             o, class_->fixedSize() - BytesPerWord),
+                       BytesPerWord);
+  }
+  return size;
 }
 
 object makeTrace(Thread* t, Processor::StackWalker* walker);


### PR DESCRIPTION
This was causing problems in the case that the computed position of the length field was misaligned and we happen to be on an architecture that doesn't allow mis-aligned loads.

The new code should be completely equivalent to the old code, since we would have effectively been multiplying by `0` before (or so I assume...).