### PR TITLE
add license title and capitalize filename

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+ISC License
+
 Copyright (c) 2008-2015, Avian Contributors
 
 Permission to use, copy, modify, and/or distribute this software for any


### PR DESCRIPTION
The title is not strictly required, but it's useful metadata, and part of the recommended license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license)

As for the filename, lowercase is fine, but since this project already uses an uppercase README as customary, using the same standard for the LICENSE file seemed to make sense.