### PR TITLE
patch Inet4AddressImpl.c to declare IcmpSendEcho2Ex

### DIFF
--- a/openjdk-patches/Inet4AddressImpl.c.8.patch
+++ b/openjdk-patches/Inet4AddressImpl.c.8.patch
@@ -1,0 +1,22 @@
+--- openjdk/Inet4AddressImpl.c
++++ openjdk/Inet4AddressImpl.c
+@@ -461,6 +461,19 @@
+     return JNI_FALSE;
+ }
+ 
++DWORD WINAPI IcmpSendEcho2Ex(HANDLE,
++			     HANDLE,
++			     LPVOID,
++			     PVOID,
++			     IPAddr,
++			     IPAddr,
++			     LPVOID,
++			     WORD,
++			     LPVOID,
++			     LPVOID,
++			     DWORD,
++			     DWORD);
++
+ /**
+  * ping implementation.
+  * Send a ICMP_ECHO_REQUEST packet every second until either the timeout


### PR DESCRIPTION
Apparently the MinGW header files don't declare it, despite it being
part of liblphlapi.a.  More confusingly, it didn't break anything for
64-bit builds because the compiler used an implicit declaration that
matched the link-time symbol name.  Alas, no such luck for 32-bit
builds, since the implicit declaration was not annotated with the @48
stdcall argument stack size, so the build died at link time.