### PR TITLE
override write(byte[]) in DeflaterOutputStream

### DIFF
--- a/classpath/java/util/zip/DeflaterOutputStream.java
+++ b/classpath/java/util/zip/DeflaterOutputStream.java
@@ -39,6 +39,10 @@ public class DeflaterOutputStream extends FilterOutputStream {
     write(buffer, 0, 1);
   }
 
+  public void write(byte[] b) throws IOException {
+    write(b, 0, b.length);
+  }
+
   public void write(byte[] b, int offset, int length) throws IOException {
     // error condition checking
     if (deflater.finished()) {


### PR DESCRIPTION
Otherwise, it will inherit the version from FilterOutputStream, which
is not consistent with the write(byte[],int,int) or write(int)
implementations.