### PR TITLE
disable Trace.java test when running on Travis-CI

### DIFF
--- a/test/Trace.java
+++ b/test/Trace.java
@@ -63,7 +63,7 @@ public class Trace implements Runnable {
     try {
       for (int i = 0; i < 10000; ++i) {
         test(this);
-        
+
         if (i % 100 == 0) {
           System.out.print("r");
           System.out.flush();
@@ -81,6 +81,13 @@ public class Trace implements Runnable {
   }
 
   public static void main(String[] args) throws Exception {
+    if ("true".equals(System.getenv("TRAVIS"))) {
+      // This test fails randomly on Travis-CI, though we've never
+      // been able to reproduce the failure elsewhere.  So we disable
+      // it if we know we're running on Travis.
+      return;
+    }
+
     Trace trace = new Trace();
     Thread thread = new Thread(trace);
 
@@ -92,7 +99,7 @@ public class Trace implements Runnable {
       while (trace.alive) {
         thread.getStackTrace();
         ++ count;
-        
+
         if (count % 100 == 0) {
           trace.wait();
           System.out.print("t");


### PR DESCRIPTION
Trace.java fails randomly on Travis, but we've never been able to
reproduce or debug the failure elsewhere, so now we skip it if we
detect the suite is running on Travis.