### PR TITLE
print informative message if lambda encountered with no host VM

### DIFF
--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -5140,6 +5140,14 @@ loop:
         PROTECT(t, bootstrapArray);
 
         if (isLambda(t, c->loader(), bootstrapArray, invocation)) {
+          if (bc->hostVM == 0) {
+            throwNew(t,
+                     GcVirtualMachineError::Type,
+                     "lambda expression encountered, but host VM is not "
+                     "available; use -hostvm option to bootimage-generator to "
+                     "fix this");
+          }
+
           JNIEnv* e;
           if (bc->hostVM->vtable->AttachCurrentThread(bc->hostVM, &e, 0) == 0) {
             e->vtable->PushLocalFrame(e, 256);


### PR DESCRIPTION
Per a recent bug report in the hello-ios project, we found that
bootimage-generator would abort with no explanation if it encountered
a lambda invocation and the `-hostvm` option was unspecified.  This
commit ensures that a helpful message is printed before exiting.