### PR TITLE
Lambda and primitive fixes

### DIFF
--- a/src/avian/constants.h
+++ b/src/avian/constants.h
@@ -258,6 +258,7 @@ const unsigned ACC_SUPER = 1 << 5;
 const unsigned ACC_SYNCHRONIZED = ACC_SUPER;
 const unsigned ACC_VOLATILE = 1 << 6;
 const unsigned ACC_TRANSIENT = 1 << 7;
+const unsigned ACC_VARARGS = 1 << 7;
 const unsigned ACC_NATIVE = 1 << 8;
 const unsigned ACC_INTERFACE = 1 << 9;
 const unsigned ACC_ABSTRACT = 1 << 10;

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -6066,8 +6066,6 @@ GcJclass* getDeclaringClass(Thread* t, GcClass* c)
 
 GcCallSite* resolveDynamic(Thread* t, GcInvocation* invocation)
 {
-  // This support for invokedynamic is limited to support for the LambdaMetafactory, as the method dispatch logic
-  // assumes the first three args are always as expected by that class. It doesn't do full indy support.
   PROTECT(t, invocation);
 
   GcClass* c = invocation->class_();
@@ -6104,8 +6102,9 @@ GcCallSite* resolveDynamic(Thread* t, GcInvocation* invocation)
       t, c->loader(), invocation->template_()->spec(), 0, 0, 0);
   PROTECT(t, type);
 
-  // There are always 3 arguments to an indy bootstrap method on top of the extras in the bootstrap array (if any),
-  // and then we must subtract the last Object[] argument in the method prototype to find the number of varargs.
+  // There are always 3 arguments to an invokedynamic bootstrap method on top of the extras in the bootstrap 
+  // array (if any), and then we must subtract the last Object[] argument in the method prototype to find 
+  // the number of varargs.
   int numVarArgs = bootstrap->flags() & ACC_VARARGS ? bootstrapArray->length() - 1 : 0;
   assertT(t, numVarArgs >= 0);
 

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -2940,8 +2940,15 @@ GcClass* makeArrayClass(Thread* t,
 
   GcArray* vtable = cast<GcArray>(t, type(t, GcJobject::Type)->virtualTable());
 
+  // From JDK docs: for array classes the public, private, protected modifiers are the same as
+  // the underlying type, and the final modifier is always set. Testing on OpenJDK shows that
+  // ACC_ABSTRACT is also set on array classes.
+  int flags = elementClass->flags() & (ACC_PUBLIC | ACC_PRIVATE | ACC_PROTECTED);
+  flags |= ACC_FINAL;
+  flags |= ACC_ABSTRACT;
+
   GcClass* c = t->m->processor->makeClass(t,
-                                          0,
+                                          flags,
                                           0,
                                           2 * BytesPerWord,
                                           BytesPerWord,
@@ -3147,10 +3154,35 @@ void bootClass(Thread* t,
     mask = 0;
   }
 
+  int flags = 0;
+  switch(type) {
+    case Gc::JbyteType:
+    case Gc::JintType:
+    case Gc::JshortType:
+    case Gc::JlongType:
+    case Gc::JbooleanType:
+    case Gc::JcharType:
+    case Gc::JfloatType:
+    case Gc::JdoubleType:
+
+    case Gc::ByteArrayType:
+    case Gc::IntArrayType:
+    case Gc::ShortArrayType:
+    case Gc::LongArrayType:
+    case Gc::BooleanArrayType:
+    case Gc::CharArrayType:
+    case Gc::FloatArrayType:
+    case Gc::DoubleArrayType:
+      // Primitive and array types are final, abstract and public.
+      flags = ACC_FINAL | ACC_ABSTRACT | ACC_PUBLIC;
+    default:
+      break;
+  }
+
   super = (superType >= 0 ? vm::type(t, static_cast<Gc::Type>(superType)) : 0);
 
   GcClass* class_ = t->m->processor->makeClass(t,
-                                               0,
+                                               flags,
                                                BootstrapFlag,
                                                fixedSize,
                                                arrayElementSize,
@@ -6034,6 +6066,8 @@ GcJclass* getDeclaringClass(Thread* t, GcClass* c)
 
 GcCallSite* resolveDynamic(Thread* t, GcInvocation* invocation)
 {
+  // This support for invokedynamic is limited to support for the LambdaMetafactory, as the method dispatch logic
+  // assumes the first three args are always as expected by that class. It doesn't do full indy support.
   PROTECT(t, invocation);
 
   GcClass* c = invocation->class_();


### PR DESCRIPTION
Couple of fixes:

1) Upgrade invokedynamic support so the altMetafactory can be used. javac sometimes emits calls to altMetafactory when a lambda is serializable or otherwise marked with additional interfaces. The code for this is kind of hacky due to the different sources of type data for when method arguments are present vs when they are not due to use of varargs. Ideally the constant pool would have all the needed type information in it, but as far as I can tell it doesn't.

2) Primitive and array classes need to be "public abstract final" for compatibility with HotSpot. Some software does rely on this, e.g. Kryo.
