### PR TITLE
add missing Unsafe calls for recent JDK 7 updates

### DIFF
--- a/makefile
+++ b/makefile
@@ -1588,6 +1588,7 @@ endif
 
 ifeq (7,$(java-version))
 	test-sources := $(subst $(test)/InvokeDynamic.java,,$(test-sources))
+	test-sources := $(subst $(test)/Interfaces.java,,$(test-sources))
 endif
 
 test-cpp-sources = $(wildcard $(test)/*.cpp)
@@ -2330,7 +2331,7 @@ ifeq ($(platform),windows)
 	echo 'static int getAddrsFromAdapter(IP_ADAPTER_ADDRESSES *ptr, netaddr **netaddrPP);' >> $(build)/openjdk/NetworkInterface.h
 endif
 
-ifeq ($(kernel),darwin)	
+ifeq ($(kernel),darwin)
 	mkdir -p $(build)/openjdk/netinet
 	for file in \
 		$(header-sysroot)/usr/include/netinet/ip.h \

--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -3134,6 +3134,18 @@ extern "C" AVIAN_EXPORT void JNICALL
   release(t, reinterpret_cast<object>(arguments[1]));
 }
 
+extern "C" AVIAN_EXPORT jboolean JNICALL
+    Avian_sun_misc_Unsafe_isBigEndian0(Thread*, object, uintptr_t*)
+{
+  return false;
+}
+
+extern "C" AVIAN_EXPORT jboolean JNICALL
+    Avian_sun_misc_Unsafe_unalignedAccess0(Thread*, object, uintptr_t*)
+{
+  return false;
+}
+
 namespace {
 
 namespace local {


### PR DESCRIPTION
Also, disable Interfaces test for JDK 7 since it uses Java 8 syntax.