### PR TITLE
Lambda fixes

### DIFF
--- a/classpath/avian/ClassAddendum.java
+++ b/classpath/avian/ClassAddendum.java
@@ -27,4 +27,6 @@ public class ClassAddendum extends Addendum {
   public Pair enclosingMethod;
 
   public VMMethod[] bootstrapMethodTable;
+
+  public VMMethod[] bootstrapLambdaTable;
 }

--- a/classpath/java/lang/invoke/CallSite.java
+++ b/classpath/java/lang/invoke/CallSite.java
@@ -1,3 +1,13 @@
+/* Copyright (c) 2008-2016, Avian Contributors
+
+   Permission to use, copy, modify, and/or distribute this software
+   for any purpose with or without fee is hereby granted, provided
+   that the above copyright notice and this permission notice appear
+   in all copies.
+
+   There is NO WARRANTY for this software.  See license.txt for
+   details. */
+
 package java.lang.invoke;
 
 public class CallSite {

--- a/classpath/java/lang/invoke/LambdaConversionException.java
+++ b/classpath/java/lang/invoke/LambdaConversionException.java
@@ -1,3 +1,13 @@
+/* Copyright (c) 2008-2016, Avian Contributors
+
+   Permission to use, copy, modify, and/or distribute this software
+   for any purpose with or without fee is hereby granted, provided
+   that the above copyright notice and this permission notice appear
+   in all copies.
+
+   There is NO WARRANTY for this software.  See license.txt for
+   details. */
+
 package java.lang.invoke;
 
 public class LambdaConversionException extends java.lang.Exception {

--- a/classpath/java/lang/invoke/LambdaMetafactory.java
+++ b/classpath/java/lang/invoke/LambdaMetafactory.java
@@ -1,3 +1,13 @@
+/* Copyright (c) 2008-2016, Avian Contributors
+
+   Permission to use, copy, modify, and/or distribute this software
+   for any purpose with or without fee is hereby granted, provided
+   that the above copyright notice and this permission notice appear
+   in all copies.
+
+   There is NO WARRANTY for this software.  See license.txt for
+   details. */
+
 package java.lang.invoke;
 
 import static avian.Stream.write1;

--- a/classpath/java/lang/invoke/LambdaMetafactory.java
+++ b/classpath/java/lang/invoke/LambdaMetafactory.java
@@ -25,17 +25,17 @@ import avian.SystemClassLoader;
 
 public class LambdaMetafactory {
   private static int nextNumber = 0;
-  
+
   private static Class resolveReturnInterface(MethodType type) {
     int index = 1;
     byte[] s = type.spec;
-    
+
     while (s[index] != ')') ++ index;
-    
+
     if (s[++ index] != 'L') throw new AssertionError();
-    
+
     ++ index;
-    
+
     int end = index + 1;
     while (s[end] != ';') ++ end;
 
@@ -52,11 +52,11 @@ public class LambdaMetafactory {
     while (array[i] != c) ++i;
     return i;
   }
-  
+
   private static String constructorSpec(MethodType type) {
     return Classes.makeString(type.spec, 0, indexOf(')', type.spec) + 1) + "V";
   }
-  
+
   private static byte[] makeFactoryCode(List<PoolEntry> pool,
                                         String className,
                                         String constructorSpec,
@@ -89,7 +89,7 @@ public class LambdaMetafactory {
     byte[] result = out.toByteArray();
     set4(result, 4, result.length - 12);
 
-    return result;    
+    return result;
   }
 
   private static byte[] makeConstructorCode(List<PoolEntry> pool,
@@ -124,7 +124,7 @@ public class LambdaMetafactory {
     byte[] result = out.toByteArray();
     set4(result, 4, result.length - 12);
 
-    return result;    
+    return result;
   }
 
   private static byte[] makeInvocationCode(List<PoolEntry> pool,
@@ -167,7 +167,7 @@ public class LambdaMetafactory {
     default: throw new AssertionError
         ("todo: implement per http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.4.3.5");
     }
-    
+
     write2(out, ConstantPool.addMethodRef
            (pool,
             Classes.makeString(implementation.method.class_.name, 0,
@@ -233,7 +233,7 @@ public class LambdaMetafactory {
     }
 
     String constructorSpec = constructorSpec(invokedType);
-    
+
     List<MethodData> methodTable = new ArrayList();
 
     try {
@@ -261,9 +261,9 @@ public class LambdaMetafactory {
     } catch (IOException e) {
       AssertionError error = new AssertionError();
       error.initCause(e);
-      throw error;      
+      throw error;
     }
-      
+
     int nameIndex = ConstantPool.addClass(pool, className);
     int superIndex = ConstantPool.addClass(pool, "java/lang/Object");
 
@@ -276,12 +276,12 @@ public class LambdaMetafactory {
     } catch (IOException e) {
       AssertionError error = new AssertionError();
       error.initCause(e);
-      throw error;      
+      throw error;
     }
 
     return out.toByteArray();
   }
-  
+
   public static CallSite metafactory(MethodHandles.Lookup caller,
                                      String invokedName,
                                      MethodType invokedType,
@@ -291,7 +291,7 @@ public class LambdaMetafactory {
     throws LambdaConversionException
   {
     byte[] classData = makeLambda(invokedName, invokedType, methodType, methodImplementation);
-    
+
     try {
       return new CallSite
         (new MethodHandle
@@ -305,5 +305,15 @@ public class LambdaMetafactory {
       error.initCause(e);
       throw error;
     }
+  }
+
+  public static CallSite altMetafactory(MethodHandles.Lookup caller,
+                                        String invokedName,
+                                        MethodType invokedType,
+                                        Object... args)
+    throws LambdaConversionException
+  {
+    // todo: handle flags
+    return metafactory(caller, invokedName, invokedType, (MethodType) args[0], (MethodHandle) args[1], (MethodType) args[2]);
   }
 }

--- a/classpath/java/lang/invoke/MethodHandle.java
+++ b/classpath/java/lang/invoke/MethodHandle.java
@@ -1,3 +1,13 @@
+/* Copyright (c) 2008-2016, Avian Contributors
+
+   Permission to use, copy, modify, and/or distribute this software
+   for any purpose with or without fee is hereby granted, provided
+   that the above copyright notice and this permission notice appear
+   in all copies.
+
+   There is NO WARRANTY for this software.  See license.txt for
+   details. */
+
 package java.lang.invoke;
 
 import avian.Classes;
@@ -6,12 +16,12 @@ import avian.SystemClassLoader;
 public class MethodHandle {
   static final int REF_invokeStatic = 6;
   static final int REF_invokeSpecial = 7;
-  
+
   final int kind;
   private final ClassLoader loader;
   final avian.VMMethod method;
   private volatile MethodType type;
-  
+
   MethodHandle(int kind, ClassLoader loader, avian.VMMethod method) {
     this.kind = kind;
     this.loader = loader;
@@ -44,7 +54,7 @@ public class MethodHandle {
     sb.append(Classes.makeString(method.spec, 0,
                                  method.spec.length - 1));
     return sb.toString();
-  }  
+  }
 
   public MethodType type() {
     if (type == null) {

--- a/classpath/java/lang/invoke/MethodHandles.java
+++ b/classpath/java/lang/invoke/MethodHandles.java
@@ -1,3 +1,13 @@
+/* Copyright (c) 2008-2016, Avian Contributors
+
+   Permission to use, copy, modify, and/or distribute this software
+   for any purpose with or without fee is hereby granted, provided
+   that the above copyright notice and this permission notice appear
+   in all copies.
+
+   There is NO WARRANTY for this software.  See license.txt for
+   details. */
+
 package java.lang.invoke;
 
 public class MethodHandles {

--- a/classpath/java/lang/invoke/MethodType.java
+++ b/classpath/java/lang/invoke/MethodType.java
@@ -1,3 +1,13 @@
+/* Copyright (c) 2008-2016, Avian Contributors
+
+   Permission to use, copy, modify, and/or distribute this software
+   for any purpose with or without fee is hereby granted, provided
+   that the above copyright notice and this permission notice appear
+   in all copies.
+
+   There is NO WARRANTY for this software.  See license.txt for
+   details. */
+
 package java.lang.invoke;
 
 import static avian.Assembler.*;

--- a/classpath/java/lang/invoke/MethodType.java
+++ b/classpath/java/lang/invoke/MethodType.java
@@ -14,7 +14,7 @@ public final class MethodType implements java.io.Serializable {
   private static final char[] Primitives = new char[] {
     'V', 'Z', 'B', 'C', 'S', 'I', 'F', 'J', 'D'
   };
-  
+
   final ClassLoader loader;
   final byte[] spec;
   private volatile List<Parameter> parameters;
@@ -31,11 +31,11 @@ public final class MethodType implements java.io.Serializable {
     this.spec = new byte[spec.length() + 1];
     spec.getBytes(0, spec.length(), this.spec, 0);
   }
-  
+
   public String toMethodDescriptorString() {
     return Classes.makeString(spec, 0, spec.length - 1);
   }
-  
+
   private static String spec(Class c) {
     if (c.isPrimitive()) {
       VMClass vmc = Classes.toVMClass(c);
@@ -56,7 +56,7 @@ public final class MethodType implements java.io.Serializable {
                      Class ... ptypes)
   {
     loader = rtype.getClassLoader();
-    
+
     StringBuilder sb = new StringBuilder();
     sb.append('(');
     parameters = new ArrayList(ptypes.length);
@@ -66,7 +66,7 @@ public final class MethodType implements java.io.Serializable {
       sb.append(spec);
 
       Type type = type(spec);
-      
+
       parameters.add(new Parameter(i,
                                    position,
                                    spec,
@@ -86,7 +86,7 @@ public final class MethodType implements java.io.Serializable {
 
     this.spec = sb.toString().getBytes();
   }
-  
+
   public static MethodType methodType(Class rtype,
                                       Class ptype0,
                                       Class ... ptypes)
@@ -129,7 +129,7 @@ public final class MethodType implements java.io.Serializable {
 
     return array;
   }
-  
+
   public Iterable<Parameter> parameters() {
     if (parameters == null) {
       List<Parameter> list = new ArrayList();
@@ -147,7 +147,7 @@ public final class MethodType implements java.io.Serializable {
         case '[': {
           ++ i;
           while (spec[i] == '[') ++ i;
-        
+
           switch (spec[i]) {
           case 'L':
             ++ i;
@@ -174,7 +174,7 @@ public final class MethodType implements java.io.Serializable {
 
         String paramSpec = Classes.makeString(spec, start, (i - start) + 1);
         Type type = type(paramSpec);
-        
+
         list.add(new Parameter
                  (index,
                   position,
@@ -192,14 +192,14 @@ public final class MethodType implements java.io.Serializable {
 
       String paramSpec = Classes.makeString(spec, i, spec.length - i - 1);
       Type type = type(paramSpec);
-      
+
       result = new Result(paramSpec,
                           Classes.forCanonicalName(loader, paramSpec),
                           type.return_);
-      
+
       parameters = list;
     }
-    
+
     return parameters;
   }
 
@@ -234,18 +234,18 @@ public final class MethodType implements java.io.Serializable {
     case 'V':
       return Type.VoidType;
 
-    default: throw new AssertionError();        
-    }    
+    default: throw new AssertionError();
+    }
   }
 
   private static enum Type {
     ObjectType(aload, areturn, 1),
     IntegerType(iload, ireturn, 1),
     FloatType(fload, freturn, 1),
-    LongType(lload, lreturn, 1),
-    DoubleType(dload, dreturn, 1),
+    LongType(lload, lreturn, 2),
+    DoubleType(dload, dreturn, 2),
     VoidType(-1, Assembler.return_, -1);
-    
+
     public final int load;
     public final int return_;
     public final int size;
@@ -256,7 +256,7 @@ public final class MethodType implements java.io.Serializable {
       this.size = size;
     }
   }
-  
+
   public static class Parameter {
     private final int index;
     private final int position;

--- a/classpath/java/lang/invoke/SerializedLambda.java
+++ b/classpath/java/lang/invoke/SerializedLambda.java
@@ -1,0 +1,48 @@
+/* Copyright (c) 2008-2016, Avian Contributors
+
+   Permission to use, copy, modify, and/or distribute this software
+   for any purpose with or without fee is hereby granted, provided
+   that the above copyright notice and this permission notice appear
+   in all copies.
+
+   There is NO WARRANTY for this software.  See license.txt for
+   details. */
+
+package java.lang.invoke;
+
+public class SerializedLambda implements java.io.Serializable {
+  public int getImplMethodKind() {
+    // todo
+    return 0;
+  }
+
+  public String getImplClass() {
+    // todo
+    return null;
+  }
+
+  public String getImplMethodName() {
+    // todo
+    return null;
+  }
+
+  public String getImplMethodSignature() {
+    // todo
+    return null;
+  }
+
+  public String getFunctionalInterfaceClass() {
+    // todo
+    return null;
+  }
+
+  public String getFunctionalInterfaceMethodName() {
+    // todo
+    return null;
+  }
+
+  public String getFunctionalInterfaceMethodSignature() {
+    // todo
+    return null;
+  }
+}

--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -523,6 +523,9 @@ class MyClasspath : public Classpath {
     GcJobject* blockerLock = makeJobject(t);
     thread->setBlockerLock(t, blockerLock);
 
+#if HAVE_ThreadName_Ljava_lang_String_
+    GcString* name = vm::makeString(t, "Thread-%p", thread);
+#else
     const unsigned BufferSize = 256;
     char buffer[BufferSize];
     unsigned length = vm::snprintf(buffer, BufferSize, "Thread-%p", thread);
@@ -530,6 +533,7 @@ class MyClasspath : public Classpath {
     for (unsigned i = 0; i < length; ++i) {
       name->body()[i] = buffer[i];
     }
+#endif
     thread->setName(t, name);
 
     return thread;

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -1220,7 +1220,7 @@ GcClassAddendum* getClassAddendum(Thread* t, GcClass* class_, GcSingleton* pool)
   if (addendum == 0) {
     PROTECT(t, class_);
 
-    addendum = makeClassAddendum(t, pool, 0, 0, 0, 0, -1, 0, 0, 0);
+    addendum = makeClassAddendum(t, pool, 0, 0, 0, 0, -1, 0, 0, 0, 0);
     setField(t, class_, ClassAddendum, addendum);
   }
   return addendum;

--- a/src/tools/type-generator/main.cpp
+++ b/src/tools/type-generator/main.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 #include <set>
 #include <sstream>
+#include <algorithm>
 
 #include "avian/constants.h"
 #include "avian/finder.h"
@@ -908,8 +909,6 @@ std::string cppFieldType(Module& module, Field* f)
 
 void writeAccessor(Output* out, Class* cl, Field* f)
 {
-  std::string typeName = f->typeName;
-
   out->write("const unsigned ");
   out->write(capitalize(cl->name));
   out->write(capitalize(f->name));
@@ -920,7 +919,22 @@ void writeAccessor(Output* out, Class* cl, Field* f)
   out->write("#define HAVE_");
   out->write(capitalize(cl->name));
   out->write(capitalize(f->name));
-  out->write(" 1\n\n");
+  out->write(" 1\n");
+
+  if (! f->javaSpec.empty()) {
+    std::string s = f->javaSpec;
+    std::replace(s.begin(), s.end(), '/', '_');
+    std::replace(s.begin(), s.end(), '$', '_');
+    std::replace(s.begin(), s.end(), ';', '_');
+    std::replace(s.begin(), s.end(), '[', '_');
+
+    out->write("#define HAVE_");
+    out->write(capitalize(cl->name));
+    out->write(capitalize(f->name));
+    out->write("_");
+    out->write(s);
+    out->write(" 1\n\n");
+  }
 }
 
 void writeAccessors(Output* out, Module& module)

--- a/test/InvokeDynamic.java
+++ b/test/InvokeDynamic.java
@@ -4,15 +4,33 @@ public class InvokeDynamic {
   private InvokeDynamic(int foo) {
     this.foo = foo;
   }
-  
+
   private interface Operation {
     int operate(int a, int b);
+  }
+
+  private interface Operation2 {
+    long operate(long a, int b);
+  }
+
+  private static class Pair<A, B> {
+    public final A first;
+    public final B second;
+
+    public Pair(A first, B second) {
+      this.first = first;
+      this.second = second;
+    }
+  }
+
+  private interface Supplier<T> extends java.io.Serializable {
+    T get();
   }
 
   private static void expect(boolean v) {
     if (! v) throw new RuntimeException();
   }
-  
+
   public static void main(String[] args) {
     int c = 4;
     Operation op = (a, b) -> a + b - c;
@@ -24,8 +42,19 @@ public class InvokeDynamic {
   }
 
   private void test() {
-    int c = 2;
-    Operation op = (a, b) -> ((a + b) * c) - foo;
-    expect(op.operate(2, 3) == ((2 + 3) * 2) - foo);
+    { int c = 2;
+      Operation op = (a, b) -> ((a + b) * c) - foo;
+      expect(op.operate(2, 3) == ((2 + 3) * 2) - foo);
+    }
+
+    { int c = 2;
+      Operation2 op = (a, b) -> ((a + b) * c) - foo;
+      expect(op.operate(2, 3) == ((2 + 3) * 2) - foo);
+    }
+
+    { Supplier<Pair<Long, Double>> s = () -> new Pair<Long, Double>(42L, 77.1D);
+      expect(s.get().first == 42L);
+      expect(s.get().second == 77.1D);
+    }
   }
 }


### PR DESCRIPTION
For lambdas that implement java.io.Serializable, the compiler emits
calls to LambdaMetaFactory.altMetafactory, not
LambdaMetaFactory.metafactory, so I've provided a stub implementation
that currently ignores the extra parameters it receives.

This also fixes a bug in compiling lambda glue code for lambdas that
take longs and/or doubles.