### PR TITLE
Added basic support for the Runtime.maxFree() method.

### DIFF
--- a/classpath/java/lang/Runtime.java
+++ b/classpath/java/lang/Runtime.java
@@ -129,6 +129,8 @@ public class Runtime {
   public native long freeMemory();
 
   public native long totalMemory();
+  
+  public native long maxMemory();
 
   private static class MyProcess extends Process {
     private long pid;

--- a/src/builtin.cpp
+++ b/src/builtin.cpp
@@ -372,6 +372,12 @@ extern "C" AVIAN_EXPORT int64_t JNICALL
 }
 
 extern "C" AVIAN_EXPORT int64_t JNICALL
+    Avian_java_lang_Runtime_maxMemory(Thread* t, object, uintptr_t*)
+{
+  return t->m->heap->limit();
+}
+
+extern "C" AVIAN_EXPORT int64_t JNICALL
     Avian_avian_avianvmresource_Handler_00024ResourceInputStream_getContentLength(
         Thread* t,
         object,

--- a/test/Misc.java
+++ b/test/Misc.java
@@ -360,6 +360,7 @@ public class Misc {
 
     // just test that it's there; don't care what it returns:
     Runtime.getRuntime().totalMemory();
+    Runtime.getRuntime().maxMemory();
   }
 
   protected class Protected { }


### PR DESCRIPTION
Added basic support for the `Runtime.maxFree()` method.  Some applications (BouncyCastle for example) expect to be able to call this method. It is implemented basically the same as `totalMemory()` since there isn't much of a difference for Avian.

Give me a ping if any changes are needed.