### PR TITLE
initialize MyThread::dynamicTable on thread creation

### DIFF
--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -1311,10 +1311,6 @@ Allocator* allocator(MyThread* t);
 
 unsigned addDynamic(MyThread* t, GcInvocation* invocation)
 {
-  if (t->dynamicTable == nullptr) {
-    t->dynamicTable = dynamicTable(t);
-  }
-
   ACQUIRE(t, t->m->classLock);
 
   int index = invocation->index();
@@ -8828,6 +8824,7 @@ class MyProcessor : public Processor {
     t->heapImage = heapImage;
     t->codeImage = codeImage;
     t->thunkTable = thunkTable;
+    t->dynamicTable = local::dynamicTable(t);
 
 #if TARGET_BYTES_PER_WORD == BYTES_PER_WORD
 


### PR DESCRIPTION
Previously, I was lazily initializing this field in addDynamic, but
that only worked if a thread compiles an invokedynamic expression
prior to the first time it executes one, which is not always the case.

This is a bit tricky to write a simple test case for, since it
involves multiple threads, but I've tested it with a big, lambda-heavy
app and it fixes an otherwise consistent crash there.