### PR TITLE
make OpenJDK build compatible with ojdkbuild artifacts

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -669,6 +669,10 @@ class MyClasspath : public Classpath {
 #  ifdef PLATFORM_WINDOWS
     expect(t, loadLibrary(t, libraryPath, "msvcr100", true, true));
 #  endif
+    // necessary for using OpenJDK builds from
+    // https://github.com/ojdkbuild/ojdkbuild:
+    loadLibrary(t, libraryPath, "ojdkbuild_zlib", true, true, false);
+
     expect(t, loadLibrary(t, libraryPath, "verify", true, true));
     expect(t, loadLibrary(t, libraryPath, "java", true, true));
 #endif  // not AVIAN_OPENJDK_SRC


### PR DESCRIPTION
One way to avoid the intense pain of building OpenJDK on Windows is to
let somebody else do it, e.g. https://github.com/ojdkbuild/ojdkbuild.
However, that project customizes the builds slightly, which means we
need to make an effort to stay compatible.  This one-liner does that.