### PR TITLE
Add support for "invokevirtual" and "invokeinterface".

### DIFF
--- a/classpath/avian/ConstantPool.java
+++ b/classpath/avian/ConstantPool.java
@@ -26,6 +26,7 @@ public class ConstantPool {
   private static final int CONSTANT_NameAndType = 12;
   private static final int CONSTANT_Fieldref = 9;
   private static final int CONSTANT_Methodref = 10;
+  private static final int CONSTANT_InterfaceMethodref = 11;
   
   public static int add(List<PoolEntry> pool, PoolEntry e) {
     int i = 0;
@@ -83,6 +84,16 @@ public class ConstantPool {
     return add(pool, new MethodRefPoolEntry
                (addClass(pool, className),
                 addNameAndType(pool, name, spec)));
+  }
+
+  public static int addInterfaceMethodRef(List<PoolEntry> pool,
+                                          String interfaceName,
+                                          String name,
+                                          String spec)
+  {
+    return add(pool, new InterfaceMethodRefPoolEntry
+               (addClass(pool, interfaceName),
+               addNameAndType(pool, name, spec)));
   }
 
   public interface PoolEntry {
@@ -232,6 +243,32 @@ public class ConstantPool {
     public boolean equals(Object o) {
       if (o instanceof MethodRefPoolEntry) {
         MethodRefPoolEntry other = (MethodRefPoolEntry) o;
+        return other.classIndex == classIndex
+          && other.nameAndTypeIndex == nameAndTypeIndex;
+      } else {
+        return false;
+      }
+    }
+  }
+
+  private static class InterfaceMethodRefPoolEntry implements PoolEntry {
+    private final int classIndex;
+    private final int nameAndTypeIndex;
+
+    public InterfaceMethodRefPoolEntry(int classIndex, int nameAndTypeIndex) {
+      this.classIndex = classIndex;
+      this.nameAndTypeIndex = nameAndTypeIndex;
+    }
+
+    public void writeTo(OutputStream out) throws IOException {
+      write1(out, CONSTANT_InterfaceMethodref);
+      write2(out, classIndex + 1);
+      write2(out, nameAndTypeIndex + 1);
+    }
+
+    public boolean equals(Object o) {
+      if (o instanceof InterfaceMethodRefPoolEntry) {
+        InterfaceMethodRefPoolEntry other = (InterfaceMethodRefPoolEntry) o;
         return other.classIndex == classIndex
           && other.nameAndTypeIndex == nameAndTypeIndex;
       } else {

--- a/classpath/java/lang/invoke/MethodHandle.java
+++ b/classpath/java/lang/invoke/MethodHandle.java
@@ -14,8 +14,10 @@ import avian.Classes;
 import avian.SystemClassLoader;
 
 public class MethodHandle {
+  static final int REF_invokeVirtual = 5;
   static final int REF_invokeStatic = 6;
   static final int REF_invokeSpecial = 7;
+  static final int REF_invokeInterface = 9;
 
   final int kind;
   private final ClassLoader loader;

--- a/test/InvokeDynamic.java
+++ b/test/InvokeDynamic.java
@@ -1,3 +1,5 @@
+import java.util.*;
+
 public class InvokeDynamic {
   private final int foo;
 
@@ -25,6 +27,40 @@ public class InvokeDynamic {
 
   private interface Supplier<T> extends java.io.Serializable {
     T get();
+  }
+
+  private interface Consumer<T> {
+    void accept(T obj);
+  }
+
+  private interface Function<T, R> {
+    R apply(T obj);
+  }
+
+  private interface BiFunction<T, U, R> {
+    R apply(T t, U u);
+  }
+
+  private interface GetLong {
+    long get(long l);
+  }
+
+  private interface GetDouble {
+    double get(double d);
+  }
+
+  private static class LongHolder implements GetLong {
+    @Override
+    public long get(long l) {
+        return l;
+    }
+  }
+
+  private static class DoubleHolder implements GetDouble {
+    @Override
+    public double get(double d) {
+        return d;
+    }
   }
 
   private static void expect(boolean v) {
@@ -92,6 +128,40 @@ public class InvokeDynamic {
     { Foo s = this::requiresBridge;
       s.someFunction(1, 2, "");
     }
+
+    { Consumer<String> c = System.out::println;
+      c.accept("invoke virtual");
+    }
+
+    { Function<CharSequence, String> f = CharSequence::toString;
+      System.out.println(f.apply("invoke interface"));
+    }
+
+    //{ Function<CharSequence, Integer> f = CharSequence::length;
+    //  System.out.println(f.apply("invoke interface"));
+    //}
+
+    //{ BiFunction<CharSequence, Integer, Character> f = CharSequence::charAt;
+    //  String data = "0123456789";
+    //  for (int i = 0; i < data.length(); ++i) {
+    //      System.out.println(f.apply(data, i));
+    //  }
+    //}
+
+    { Function<java.util.List<String>, Iterator<String>> f = java.util.List<String>::iterator;
+      Iterator<String> iter = f.apply(Arrays.asList("1", "22", "333"));
+      while (iter.hasNext()) {
+        System.out.println(iter.next());
+      }
+    }
+
+    //{ BiFunction<GetLong, Long, Long> f = GetLong::get;
+    //  System.out.println("Long: " + f.apply(new LongHolder(), 20L));
+    //}
+
+    //{ BiFunction<GetDouble, Double, Double> f = GetDouble::get;
+    //  System.out.println("DoubleHolder: " + f.apply(new DoubleHolder(), 20d));
+    //}
 
     // This abort()s in machine.cpp
     // { Foo s = (Foo & Marker) this::requiresBridge;


### PR DESCRIPTION
Trying to use a function reference on Avian (compiled against OpenJDK):
```java
List<String> list = asList(args);
int totalChars = list.stream().mapToInt(String::length).sum();
```

resulted in this error:

todo: implement per [http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.4.3.5](http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-5.html#jvms-5.4.3.5)

Following the link revealed that Avian lacked support for `invokevirtual`, which is now trivially(?) fixed. For an encore, I then implemented `invokeinterface` as well.