### PR TITLE
Fix crash when resolving system classes.

### DIFF
--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -4881,13 +4881,7 @@ GcClass* resolveSystemClass(Thread* t,
 
   ACQUIRE(t, t->m->classLock);
 
-  GcClass* class_ = cast<GcClass>(t,
-                                  hashMapFind(t,
-                                              cast<GcHashMap>(t, loader->map()),
-                                              spec,
-                                              byteArrayHash,
-                                              byteArrayEqual));
-
+  GcClass* class_ = findLoadedClass(t, loader, spec);
   if (class_ == 0) {
     PROTECT(t, class_);
 


### PR DESCRIPTION
I uncovered this crash when trying to write a classloader that extends `avian.SystemClassLoader`. The problem is that `loader->map()` can return `NULL`, but the `resolveSystemClass()` function doesn't check for this. However, this check _is_ built into the `findLoadedClass()` function, so use that instead.

Having said this, I am wondering if `avian.SystemClassLoader` is _supposed_ to be extended in the first place. Consider this test case, which currently fails because the class returned by `findClass()` doesn't have `myLoader` as its classloader, despite the class having been loaded by it:
```java
import java.io.IOException;
import java.io.File;
import java.io.FileInputStream;

public class CustomClassLoaders {
  private static void expect(boolean v) {
    if (! v) throw new RuntimeException();
  }

  private static void testClassLoader() throws Exception {
    MyClassLoader myLoader = new MyClassLoader();
    Class<?> myClass = myLoader.findClass("CustomClassLoaders$Hello");
    expect(myClass.getClassLoader() == myLoader);
  }

  public static void main(String[] args) throws Exception {
    testClassLoader();
  }

  public static class Hello {
    public static void main(String[] args) {
      System.out.println("hello, world!");
    }
  }

  private static class MyClassLoader extends avian.SystemClassLoader {
    @Override
    public Class<?> findClass(String name) throws ClassNotFoundException {
      return super.findClass(name);
    }
  }
}
```
The OpenJDK equivalent of `MyClassLoader` would look like this:
```java
  private static class MyClassLoader extends java.net.URLClassLoader {
    MyClassLoader(ClassLoader parent) {
        super(((URLClassLoader)parent).getURLs(), parent);
    }

    @Override
    public Class<?> findClass(String name) throws ClassNotFoundException {
      return super.findClass(name);
    }
  }
```
And this _does_ associate class `Hello` with my custom classloader, so Avian's classloading semantics look different to me.