### PR TITLE
Refactor partially implemented getVMClass(Object) function.

### DIFF
--- a/classpath/avian/Classes.java
+++ b/classpath/avian/Classes.java
@@ -41,8 +41,6 @@ public class Classes {
 
   public static native boolean isAssignableFrom(VMClass a, VMClass b);
 
-  public static native VMClass getVMClass(Object o);
-
   public static native VMClass toVMClass(Class c);
 
   public static native VMMethod toVMMethod(Method m);

--- a/classpath/java/lang/Class.java
+++ b/classpath/java/lang/Class.java
@@ -564,7 +564,7 @@ public final class Class <T>
 
   public static boolean isInstance(VMClass c, Object o) {
     return o != null && Classes.isAssignableFrom
-      (c, Classes.getVMClass(o));
+      (c, o.getVMClass());
   }
 
   public boolean isInstance(Object o) {

--- a/classpath/java/lang/Object.java
+++ b/classpath/java/lang/Object.java
@@ -28,10 +28,10 @@ public class Object {
   protected void finalize() throws Throwable { }
 
   public final Class<? extends Object> getClass() {
-    return avian.SystemClassLoader.getClass(getVMClass(this));
+    return avian.SystemClassLoader.getClass(getVMClass());
   }
 
-  private static native avian.VMClass getVMClass(Object o);
+  native avian.VMClass getVMClass();
 
   public native int hashCode();
 


### PR DESCRIPTION
The static `avian.Classes.getVMClass(Object)` funtion is unimplemented because its implementation has been migrated to `Object.getVMClass(Object)`. However, this would be better written as a member function `Object.getVMClass()` instead. So:
- Remove the unimplemented `avian.Classes.getVMClass(Object)` function.
- Make `Object.getVMClass()` both non-static and package private.