### PR TITLE
Support Thread.uncaughtExceptionHandler with OpenJDK

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -981,11 +981,16 @@ void uncaughtException(Thread *t, GcThrowable *e)
                                      "(Ljava/lang/Throwable;)V");
   if (dispatch != NULL) {
     THREAD_RESOURCE0(t, {
-      // We ignore any exceptions from the uncaught
-      // exception handler itself.
-      t->exception = NULL;
+      if (t->exception != NULL) {
+        // We ignore any exceptions from the uncaught
+        // exception handler itself.
+        t->exception = NULL;
 
-      disposeThread(t);
+        // The stack will be unwound when this resource is
+        // released, which means that uncaughtException()
+        // will not return. So repeat the thread clean-up here.
+        disposeThread(t);
+      }
     });
 
     t->m->processor->invoke(t, dispatch, t->javaThread, e);

--- a/test/ThreadExceptions.java
+++ b/test/ThreadExceptions.java
@@ -46,5 +46,26 @@ public class ThreadExceptions {
       expect("TEST-HANDLER".equals(handler.message));
     }
 
+    { Thread thread = new Thread() {
+        @Override
+        public void run() {
+          throw new RuntimeException("TEST-BAD-HANDLER");
+        }
+      };
+
+      Handler handler = new Handler() {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+          super.uncaughtException(t, e);
+          throw new IllegalStateException("BAD THING");
+        }
+      };
+      thread.setUncaughtExceptionHandler(handler);
+      thread.start();
+      thread.join();
+
+      expect("TEST-BAD-HANDLER".equals(handler.message));
+      System.out.println("Exception from UncaughtExceptionHandler was ignored");
+    }
   }
 }

--- a/test/ThreadExceptions.java
+++ b/test/ThreadExceptions.java
@@ -1,0 +1,50 @@
+public class ThreadExceptions {
+
+  private static void expect(boolean v) {
+    if (! v) throw new RuntimeException("Expectation failed");
+  }
+
+  private static class Handler implements Thread.UncaughtExceptionHandler {
+    public String message;
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        message = e.getMessage();
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    { Thread thread = new Thread() {
+        @Override
+        public void run() {
+          throw new RuntimeException("TEST-DEFAULT-HANDLER");
+        }
+      };
+
+      Handler handler = new Handler();
+      Thread.setDefaultUncaughtExceptionHandler(handler);
+      thread.start();
+      thread.join();
+
+      expect("TEST-DEFAULT-HANDLER".equals(handler.message));
+    }
+
+    Thread.setDefaultUncaughtExceptionHandler(null);
+
+    { Thread thread = new Thread() {
+        @Override
+        public void run() {
+          throw new RuntimeException("TEST-HANDLER");
+        }
+      };
+
+      Handler handler = new Handler();
+      thread.setUncaughtExceptionHandler(handler);
+      thread.start();
+      thread.join();
+
+      expect("TEST-HANDLER".equals(handler.message));
+    }
+
+  }
+}

--- a/test/Threads.java
+++ b/test/Threads.java
@@ -6,7 +6,7 @@ public class Threads implements Runnable {
   }
 
   public static void main(String[] args) throws Exception {
-    ((Thread.UncaughtExceptionHandler) Thread.currentThread().getThreadGroup())
+    Thread.currentThread().getThreadGroup()
       .uncaughtException(Thread.currentThread(), new Exception());
 
     { Threads test = new Threads();


### PR DESCRIPTION
I have noticed that Avian doesn't support `Thread.uncaughtExceptionHandler` properly when compiled with OpenJDK. ~~This PR _almost_ does what I need except that I have noticed that the test cases are failing because `Thread.join()` isn't waiting for the `uncaughtExceptionHandler` to be executed.~~

~~The test case passes when Avian is _not_ compiled against OpenJDK, e.g.~~

> $ make clean test

~~My test case also passes when executed by both Oracle's JVM and OpenJDK itself, and all JVMs (including Avian) execute `uncaughtExceptionHandler` in the child thread. It therefore seems reasonable for `Thread.join()` to wait until the handler has executed too.~~

I have refactored how this works so that `uncaughtExceptionHandler` is now invoked _before_ `ActiveFlag` is cleared. This allows `Thread.join()` to wait correctly.