### PR TITLE
Fix "fallthrough" warnings with recent GCC.

### DIFF
--- a/src/debug-util.cpp
+++ b/src/debug-util.cpp
@@ -571,6 +571,7 @@ int printInstruction(uint8_t* code, unsigned& ip, const char* prefix)
       return fprintf(stderr, "wide astore %4d", read16(code, ip));
     case iinc:
       fprintf(stderr, "wide iinc %4d %4d", read16(code, ip), read16(code, ip));
+      /* fallthrough */
     case iload:
       return fprintf(stderr, "wide iload %4d", read16(code, ip));
     case istore:
@@ -582,10 +583,10 @@ int printInstruction(uint8_t* code, unsigned& ip, const char* prefix)
     case ret:
       return fprintf(stderr, "wide ret %4d", read16(code, ip));
 
-    default: {
+    default:
       fprintf(
           stderr, "unknown wide instruction %2d %4d", instr, read16(code, ip));
-    }
+      break;
     }
   }
 

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -4103,6 +4103,7 @@ void enter(Thread* t, Thread::State s)
     } else {
       // fall through to slow path
     }
+    /* fallthrough */
 
   case Thread::ZombieState: {
     ACQUIRE_LOCK;


### PR DESCRIPTION
Recent GCC, e.g. in my case:

    gcc (GCC) 7.1.1 20170622 (Red Hat 7.1.1-3)

warns about `case` statements that "fall through" to the ones below. The solution is to comment them explicitly.