### PR TITLE
Allow any uncaught exception to be logged as the thread exits.

### DIFF
--- a/src/classpath-openjdk.cpp
+++ b/src/classpath-openjdk.cpp
@@ -982,10 +982,6 @@ void uncaughtException(Thread *t, GcThrowable *e)
   if (dispatch != NULL) {
     THREAD_RESOURCE0(t, {
       if (t->exception != NULL) {
-        // We ignore any exceptions from the uncaught
-        // exception handler itself.
-        t->exception = NULL;
-
         // The stack will be unwound when this resource is
         // released, which means that uncaughtException()
         // will not return. So repeat the thread clean-up here.


### PR DESCRIPTION
Not clearing the uncaught exception here means that it will be logged in `Thread::Runnable::run()`:
```C++
  vm::run(t, runThread, 0);

  if (t->exception and t->exception != roots(t)->shutdownInProgress()) {
    printTrace(t, t->exception);
  }
```
This is not a bad thing.