### PR TITLE
Changes return type to StringBuilder

### DIFF
--- a/classpath/java/lang/StringBuilder.java
+++ b/classpath/java/lang/StringBuilder.java
@@ -62,7 +62,7 @@ public class StringBuilder implements CharSequence, Appendable {
     return append(sequence.toString());
   }
 
-  public Appendable append(CharSequence sequence, int start, int end) {
+  public StringBuilder append(CharSequence sequence, int start, int end) {
     return append(sequence.subSequence(start, end));
   }
 


### PR DESCRIPTION
I get a method not found exception when using the `StringBuilder` because it returns an `Appendable` type rather than a `StringBuilder` type.