### PR TITLE
Support proper minimum version instead of fishing the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ certain flags described below, all of which are optional.
         use-clang={true,false} \
         openjdk=<openjdk installation directory> \
         openjdk-src=<openjdk source directory> \
-        android=<android source directory>
+        android=<android source directory> \
+        ios-version=<iOS minimum version>
 
   * `platform` - the target platform
     * _default:_ output of $(uname -s | tr [:upper:] [:lower:]),
@@ -158,6 +159,12 @@ the OpenJDK Class Library" below for details.
 default Avian class library.  See "Building with the Android Class
 Library" below for details.
     * _default:_ not set
+
+  * `ios-version` - the minimum iOS SDK version which will be used
+when compiling for ios target. Do not use a value 11.0 or larger,
+if you want to support 32 bit version. This option is only valid
+for platform=ios .
+    * _default:_ 8.0
 
 These flags determine the name of the directory used for the build.
 The name always starts with _${platform}-${arch}_, and each non-default

--- a/makefile
+++ b/makefile
@@ -776,7 +776,6 @@ ifeq ($(kernel),darwin)
 	ifeq ($(platform),ios)
 		ifeq ($(sim),true)
 			target = iPhoneSimulator
-			sdk = iphonesimulator$(ios-version)
 			ifeq ($(arch),i386)
 				arch-flag = -arch i386
 			else
@@ -786,7 +785,6 @@ ifeq ($(kernel),darwin)
 			release = Release-iphonesimulator
 		else
 			target = iPhoneOS
-			sdk = iphoneos$(ios-version)
 			ifeq ($(arch),arm)
 				arch-flag = -arch armv7
 			else
@@ -799,16 +797,11 @@ ifeq ($(kernel),darwin)
 		platform-dir = $(developer-dir)/Platforms/$(target).platform
 		sdk-dir = $(platform-dir)/Developer/SDKs
 
-		ios-version := $(shell for x in 10.3 10.2 10.1 10.0 9.3 9.2 9.1 9.0 8.3 8.2 8.1 8.0; \
-			do if test -d $(sdk-dir)/$(target)$$x.sdk \
-				-o -L $(sdk-dir)/$(target)$$x.sdk; \
-			then echo $$x; break; fi; done)
-
 		ifeq ($(ios-version),)
-			x := $(error "couldn't find SDK in $(sdk-dir)")
+			ios-version := 8.0
 		endif
 
-		sysroot = $(sdk-dir)/$(target)$(ios-version).sdk
+		sysroot = $(sdk-dir)/$(target).sdk
 
 # apparently, the header files we need are part of the simulator SDK
 # but not the device SDK, so we copy them from the former even if
@@ -832,7 +825,7 @@ ifeq ($(kernel),darwin)
 			cc = $(ios-bin)/gcc
 		endif
 
-		flags = -isysroot $(sdk-dir)/$(target)$(ios-version).sdk \
+		flags = -isysroot $(sdk-dir)/$(target).sdk \
 			$(arch-flag)
 
 		classpath-extra-cflags += $(flags)


### PR DESCRIPTION
The current scheme of iOS version has a few problems:

- It compiles as minimum version the latest version
- There is no way to define the minimum version
- The newest SDK supports only 64 bit mode, since 32 bit was dropped; so an older SDK version is required
- It tries to guess the latest version from a filename scheme, which is fragile and changes in any new SDK version. Actually this is not even necessary since there is a version-less location of the latest SDK.

Please consider this pull request as a base to discuss how these issues could be solved