### PR TITLE
Minimum viable fix for enums from vm namespaces clashing with identifiers from includes

### DIFF
--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -3976,16 +3976,16 @@ lir::TernaryOperation toCompilerBinaryOp(MyThread* t, unsigned instruction)
   case iushr:
   case lushr:
     return lir::UnsignedShiftRight;
-  case fadd:
+  case ::vm::fadd:
   case dadd:
     return lir::FloatAdd;
-  case fsub:
+  case ::vm::fsub:
   case dsub:
     return lir::FloatSubtract;
-  case fmul:
+  case ::vm::fmul:
   case dmul:
     return lir::FloatMultiply;
-  case fdiv:
+  case ::vm::fdiv:
   case ddiv:
     return lir::FloatDivide;
   case frem:
@@ -4573,10 +4573,10 @@ loop:
                        c->f2i(ir::Type::i8(), frame->pop(ir::Type::f4())));
     } break;
 
-    case fadd:
-    case fsub:
-    case fmul:
-    case fdiv:
+    case ::vm::fadd:
+    case ::vm::fsub:
+    case ::vm::fmul:
+    case ::vm::fdiv:
     case frem: {
       ir::Value* a = frame->pop(ir::Type::f4());
       ir::Value* b = frame->pop(ir::Type::f4());

--- a/src/debug-util.cpp
+++ b/src/debug-util.cpp
@@ -140,7 +140,7 @@ int printInstruction(uint8_t* code, unsigned& ip, const char* prefix)
     return fprintf(stderr, "f2i");
   case f2l:
     return fprintf(stderr, "f2l");
-  case fadd:
+  case ::vm::fadd:
     return fprintf(stderr, "fadd");
   case faload:
     return fprintf(stderr, "faload");
@@ -156,15 +156,15 @@ int printInstruction(uint8_t* code, unsigned& ip, const char* prefix)
     return fprintf(stderr, "fconst_1");
   case fconst_2:
     return fprintf(stderr, "fconst_2");
-  case fdiv:
+  case ::vm::fdiv:
     return fprintf(stderr, "fdiv");
-  case fmul:
+  case ::vm::fmul:
     return fprintf(stderr, "fmul");
   case fneg:
     return fprintf(stderr, "fneg");
   case frem:
     return fprintf(stderr, "frem");
-  case fsub:
+  case ::vm::fsub:
     return fprintf(stderr, "fsub");
 
   case getfield:

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -1693,7 +1693,7 @@ void disassembleCode(const char* prefix, uint8_t* code, unsigned length)
     case f2l:
       fprintf(stderr, "f2l\n");
       break;
-    case fadd:
+	case ::vm::fadd:
       fprintf(stderr, "fadd\n");
       break;
     case faload:
@@ -1717,10 +1717,10 @@ void disassembleCode(const char* prefix, uint8_t* code, unsigned length)
     case fconst_2:
       fprintf(stderr, "fconst_2\n");
       break;
-    case fdiv:
+	case ::vm::fdiv:
       fprintf(stderr, "fdiv\n");
       break;
-    case fmul:
+	case ::vm::fmul:
       fprintf(stderr, "fmul\n");
       break;
     case fneg:
@@ -1729,7 +1729,7 @@ void disassembleCode(const char* prefix, uint8_t* code, unsigned length)
     case frem:
       fprintf(stderr, "frem\n");
       break;
-    case fsub:
+	case ::vm::fsub:
       fprintf(stderr, "fsub\n");
       break;
 


### PR DESCRIPTION
Various identifiers from Avian's vm::OpCode enum  - fadd, fmul, fsub, fdiv -  clash with fadd, fmul, fsub, fdiv declared elsewhere when compiling on a modern Linux system. This patch is a kludge obviously, but given that this is not an actively maintained project, I chose to make it as small as possible so it doesn't clash with other patches in future.