### PR TITLE
Patch for multiple integer overflows (CVE-2020-17360) and silent return on negative length (CVE-2020-17361)

### DIFF
--- a/src/avian/classpath-common.h
+++ b/src/avian/classpath-common.h
@@ -104,7 +104,7 @@ void arrayCopy(Thread* t,
             throwNew(t, GcIndexOutOfBoundsException::Type);
           }
         } else if (LIKELY(length < 0)) {
-          throwNew(t, GcNegativeArraySizeException::Type, "%d", length);
+          throwNew(t, GcIndexOutOfBoundsException::Type, "%d", length);
           return;
         } else {
           return;

--- a/src/avian/classpath-common.h
+++ b/src/avian/classpath-common.h
@@ -81,8 +81,8 @@ void arrayCopy(Thread* t,
         intptr_t sl = fieldAtOffset<uintptr_t>(src, BytesPerWord);
         intptr_t dl = fieldAtOffset<uintptr_t>(dst, BytesPerWord);
         if (LIKELY(length > 0)) {
-          if (LIKELY(srcOffset >= 0 and srcOffset + length <= sl
-                     and dstOffset >= 0 and dstOffset + length <= dl)) {
+          if (LIKELY(srcOffset >= 0 and srcOffset + length > srcOffset and srcOffset + length <= sl
+                     and dstOffset >= 0 and dstOffset + length > dstOffset and dstOffset + length <= dl)) {
             uint8_t* sbody = &fieldAtOffset<uint8_t>(src, ArrayBody);
             uint8_t* dbody = &fieldAtOffset<uint8_t>(dst, ArrayBody);
             if (src == dst) {
@@ -103,6 +103,9 @@ void arrayCopy(Thread* t,
           } else {
             throwNew(t, GcIndexOutOfBoundsException::Type);
           }
+        } else if (LIKELY(length < 0)) {
+          throwNew(t, GcNegativeArraySizeException::Type, "%d", length);
+          return;
         } else {
           return;
         }


### PR DESCRIPTION
This patch will fix the following security issues in arrayCopy:
-Two integer overflows resulting in out-of-bounds read/write (CVE-2020-17360).
-A silent return when negative lengths are provided. This could result in data being lost during the copy, with varying consequences depending on the subsequent use of the destination buffer (CVE-2020-17361).
