### PR TITLE
Added MacOSXFileSystemProvider to proguard

### DIFF
--- a/openjdk.pro
+++ b/openjdk.pro
@@ -259,6 +259,7 @@
 # loaded via reflection from DefaultFileSystemProvider:
 -keep class sun.nio.fs.LinuxFileSystemProvider
 -keep class sun.nio.fs.BsdFileSystemProvider
+-keep class sun.nio.fs.MacOSXFileSystemProvider
 
 # loaded via JNI in UnixNativeDispatcher.c:
 -keep class sun.nio.fs.UnixFileAttributes {


### PR DESCRIPTION
This class was missing and is required because it's also loaded by reflection from DefaultFileSystemProvider